### PR TITLE
docs: community files (CoC, PR/issue templates) + cats@ email

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something isn't working
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## What happened?
+<!-- Describe the bug clearly. -->
+
+## What did you expect?
+<!-- What should have happened instead? -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Environment
+- **OS:** (e.g., Ubuntu 22.04, macOS 14.0)
+- **Docker version:** (`docker --version`)
+- **Services running:** (e.g., editor + API + asterisk)
+- **Commit / version:** (`git log -1 --oneline`)
+
+## Logs
+<!-- Relevant logs from `docker compose logs <service>`. -->
+
+```
+paste logs here
+```
+
+## Screenshots (if applicable)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve?
+<!-- Describe the use case or pain point. -->
+
+## Proposed solution
+<!-- How do you think this should work? -->
+
+## Alternatives considered
+<!-- Any other approaches you thought about. -->
+
+## Additional context
+<!-- Screenshots, links, related issues. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for contributing! Please fill out this template to help us review your PR quickly.
+-->
+
+## Summary
+<!-- What does this PR do? 1-3 sentences. -->
+
+## Linked issue
+Closes #<!-- issue number -->
+
+## Type of change
+<!-- Check one -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no functional change)
+- [ ] Documentation
+- [ ] CI / tooling
+- [ ] Breaking change
+
+## How to test
+<!-- Steps a reviewer can follow to verify your changes work. -->
+
+1.
+2.
+3.
+
+## Screenshots (UI changes only)
+<!-- Before / After screenshots for any editor UI changes. Delete this section if not applicable. -->
+
+## Checklist
+- [ ] This PR targets the `staging` branch (not `main`)
+- [ ] Code builds: `docker compose build <service>`
+- [ ] Types pass: `cd editor && npx tsc --noEmit` (if touching editor)
+- [ ] No secrets committed (`.env`, `firebase-sa-key.json`, API keys, etc.)
+- [ ] Only shadcn/ui components used (if touching editor UI)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+
+## Notes for the reviewer
+<!-- Anything non-obvious? Tradeoffs you made? Leftover TODOs? -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**cats@astradial.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,13 +67,38 @@ Check [GitHub Issues](https://github.com/astradial/astradial/issues) for open ta
 
 ```
 astradial/
-├── editor/          # Next.js frontend (dashboard, CRM, etc.)
+├── editor/          # Next.js frontend (dashboard, CRM, AI bot editor)
 ├── api/             # Node.js API server (AstraPBX)
 ├── asterisk/        # Asterisk PBX Docker config
+├── pipecat-flow/    # AI voice bot gateway (FastAPI + Gemini Live)
 ├── workflow-engine/ # Bull job scheduler
 ├── docker-compose.yml
 └── .env.example
 ```
+
+## Pull requests
+
+Before opening a PR:
+
+- [ ] Code builds: `docker compose build <service>`
+- [ ] Types pass: `cd editor && npx tsc --noEmit` (for editor changes)
+- [ ] The PR targets `staging`, not `main`
+- [ ] The PR description links the issue with `Closes #<number>`
+- [ ] No `.env`, `firebase-sa-key.json`, or any secret committed
+
+## Reporting bugs
+
+Open an [issue](https://github.com/astradial/astradial/issues/new) with:
+
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- Your environment (OS, Docker version, which services were running)
+- Relevant logs from `docker compose logs <service>`
+
+## Security
+
+If you find a security vulnerability, **do not open a public issue**. Email **cats@astradial.com** with the details. We'll respond within 48 hours.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - [GitHub Discussions](https://github.com/astradial/astradial/discussions)
 - [Documentation](https://docs.astradial.com)
-- Email: [support@astradial.com](mailto:support@astradial.com)
+- Email: [cats@astradial.com](mailto:cats@astradial.com)

--- a/api/docs/API_SPECIFICATION.yaml
+++ b/api/docs/API_SPECIFICATION.yaml
@@ -41,7 +41,7 @@ info:
   version: 1.0.0
   contact:
     name: Astradial Support
-    email: support@astradial.com
+    email: cats@astradial.com
     url: https://astradial.com
 
 servers:

--- a/editor/components/layout/Sidebar.tsx
+++ b/editor/components/layout/Sidebar.tsx
@@ -183,7 +183,7 @@ export function Sidebar({ orgId, orgName }: SidebarProps) {
           <ShieldCheck className="h-4 w-4 shrink-0" />
           <span>Role Permissions</span>
         </Link>
-        <a href="mailto:admin@astradial.com?subject=Feature%20Request" className="flex items-center gap-2.5 px-2 py-1.5 rounded-md text-[13px] text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors">
+        <a href="mailto:cats@astradial.com?subject=Feature%20Request" className="flex items-center gap-2.5 px-2 py-1.5 rounded-md text-[13px] text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors">
           <Lightbulb className="h-4 w-4 shrink-0" />
           <span>Request Feature</span>
         </a>


### PR DESCRIPTION
## Summary
Community files and email standardization (see #10 for details).

- Add CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
- Add PR template and issue templates (bug_report, feature_request)
- Update CONTRIBUTING.md
- Standardize all public emails to cats@astradial.com

## Why staging → main
These files show up on the public repo homepage (GitHub auto-detects CoC, templates, etc.). Shipping to main so external contributors see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)