### PR TITLE
docs: add WhatsApp community group link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 WhatsApp Community Group
+    url: https://chat.whatsapp.com/EvFHEFLEwOPGNzyhG5QH2s?mode=gi_t
+    about: Chat with contributors and maintainers in real-time
+  - name: 💭 GitHub Discussions
+    url: https://github.com/astradial/astradial/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: 📚 Documentation
+    url: https://docs.astradial.com
+    about: Read the docs before opening an issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,4 +102,5 @@ If you find a security vulnerability, **do not open a public issue**. Email **ca
 
 ## Questions?
 
-Open a [Discussion](https://github.com/astradial/astradial/discussions) on GitHub.
+- Join the [WhatsApp community group](https://chat.whatsapp.com/EvFHEFLEwOPGNzyhG5QH2s?mode=gi_t) for quick help and real-time chat
+- Open a [Discussion](https://github.com/astradial/astradial/discussions) on GitHub for longer conversations

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Community
 
+- 💬 [WhatsApp Group](https://chat.whatsapp.com/EvFHEFLEwOPGNzyhG5QH2s?mode=gi_t) — chat with contributors and maintainers
 - [GitHub Discussions](https://github.com/astradial/astradial/discussions)
 - [Documentation](https://docs.astradial.com)
 - Email: [cats@astradial.com](mailto:cats@astradial.com)


### PR DESCRIPTION
## Summary
Added the WhatsApp community group link in 3 places so contributors can easily find real-time help.

## Changes
- **README.md** — added to Community section (first item)
- **CONTRIBUTING.md** — added to Questions section
- **.github/ISSUE_TEMPLATE/config.yml** — new file that shows WhatsApp + Discussions + Docs links when users click "New issue" on GitHub (reduces noise from questions being filed as issues)

## Test plan
- [ ] Click "New issue" on the repo — contact_links should show WhatsApp, Discussions, Docs
- [ ] Verify WhatsApp link opens the group successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)