### PR TITLE
docs: add README badges (license, stars, issues, PRs, contributors, last commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Astradial
 
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/astradial/astradial?style=social)](https://github.com/astradial/astradial/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/astradial/astradial)](https://github.com/astradial/astradial/issues)
+[![GitHub PRs](https://img.shields.io/github/issues-pr/astradial/astradial)](https://github.com/astradial/astradial/pulls)
+[![Contributors](https://img.shields.io/github/contributors/astradial/astradial)](https://github.com/astradial/astradial/graphs/contributors)
+[![Last commit](https://img.shields.io/github/last-commit/astradial/astradial)](https://github.com/astradial/astradial/commits/main)
+
 Everything your business needs to talk to customers — phone numbers, call queues, CRM, AI bots. One app, open source.
 
 Astradial is an open-source phone system for businesses. It handles call routing, CRM, AI voice bots, and automation — all in one app you can self-host with Docker.


### PR DESCRIPTION
## Summary

Per #17, add a row of shields.io badges right under the `# Astradial` heading so visitors get the license/activity/community at a glance. Kept the set to the six called out in the issue body.

## Badges added

- License (AGPL v3, links to `./LICENSE`)
- GitHub stars
- GitHub issues
- GitHub PRs
- Contributors
- Last commit

## Notes

- License badge links to `./LICENSE` in-repo rather than gnu.org so readers don't have to leave GitHub.
- The CI workflow status badges mentioned in #29 are intentionally out of scope here -- that issue is blocked on the Docker build CI (#4) so the badge URLs wouldn't resolve yet.

Fixes #17
