### PR TITLE
docs: simplify PR workflow — contributors target main directly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Closes #<!-- issue number -->
 <!-- Before / After screenshots for any editor UI changes. Delete this section if not applicable. -->
 
 ## Checklist
-- [ ] This PR targets the `staging` branch (not `main`)
+- [ ] This PR targets the `main` branch
 - [ ] Code builds: `docker compose build <service>`
 - [ ] Types pass: `cd editor && npx tsc --noEmit` (if touching editor)
 - [ ] No secrets committed (`.env`, `firebase-sa-key.json`, API keys, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,23 @@ Editor runs at http://localhost:3001 with hot reload. Backend services run in Do
 ## Git workflow
 
 ```
-feature/your-feature  →  PR to staging  →  test  →  PR to main  →  release
+fork  →  feature branch from main  →  PR to main  →  review + test  →  merge
 ```
 
-1. Create a branch from `staging`: `git checkout -b feature/your-feature staging`
-2. Make your changes
-3. Run type check: `cd editor && npx tsc --noEmit`
-4. Commit with conventional format (see below)
-5. Push and create a PR to `staging`
-6. After review and testing, PR from `staging` to `main`
+1. **Fork** the repo on GitHub
+2. **Clone your fork** and create a branch from `main`:
+   ```bash
+   git checkout -b feat/your-feature main
+   ```
+3. **Make your changes**
+4. **Run type check** (if touching the editor): `cd editor && npx tsc --noEmit`
+5. **Commit** with conventional format (see below)
+6. **Push** to your fork and **open a PR** targeting the `main` branch
+7. Maintainer reviews, tests, and merges
 
-Never push directly to `staging` or `main`.
+**PRs go directly to `main`.** Main is protected — only approved PRs can merge. Maintainers test the PR (locally or on open.astradial.com) before approving.
+
+> ℹ️ We previously used a `staging → main` flow. As of April 2026, we simplified to single-branch. Open PRs to `main` directly.
 
 ## Commit messages
 


### PR DESCRIPTION
## Summary
Change the contributor workflow from `feature → staging → main` to `feature → main` directly.

## Why
- Every contributor so far got the base branch wrong
- Staging as a branch had no deployment value in OSS (only main does)
- The extra merge step added friction without adding safety

## What changes
- **CONTRIBUTING.md** — workflow section now says PRs go directly to `main`
- **PR template** — checklist item now says "targets `main`" (was "targets `staging`")

## Safety preserved
- `main` is still protected — external PRs can't merge without an approving review
- Maintainers still test the PR (locally or on open.astradial.com) before approving
- Nothing changes about how maintainers review

## Test plan
- [x] New contributors opening PRs will default to `main` (GitHub default) — zero friction
- [ ] @MUTHUMANIKANDAN11 to approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)