### PR TITLE
feat: add /api/healthz endpoint + docker healthcheck (#16)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,12 @@ services:
       - GATEWAY_ADMIN_KEY=${INTERNAL_API_KEY:-internal-dev-key}
     networks:
       - astradial
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/api/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   workflow-engine:
     build: ./workflow-engine

--- a/editor/app/api/healthz/route.ts
+++ b/editor/app/api/healthz/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    service: 'editor',
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
Cherry-pick of @xtreellaDev's healthz endpoint from staging → main (only the 2 actual files, no conflict noise).

Replaces PR #35 which had merge conflicts due to staging/main divergence.

## What's in this PR
- `editor/app/api/healthz/route.ts` — new endpoint returning `{ status, service, timestamp }`
- `docker-compose.yml` — Docker healthcheck for editor service

## Why cherry-pick instead of staging→main merge
Main and staging diverged (community docs, badges, workflow changes all landed on main via direct PRs). A staging→main merge had 12-file conflicts. Cherry-picking the one new commit avoids all that.

## Credit
Original work by @xtreellaDev in PR #16. `Co-Authored-By` header preserves attribution.

## Test plan
- [x] Already tested and approved on staging
- [ ] @MUTHUMANIKANDAN11 to approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)