### PR TITLE
Add password toggle to user and trunk dialogs

### DIFF
--- a/editor/app/dashboard/[orgId]/trunks/page.tsx
+++ b/editor/app/dashboard/[orgId]/trunks/page.tsx
@@ -16,6 +16,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { showToast } from "@/components/ui/Toast";
 import { trunks, type PbxTrunk } from "@/lib/pbx/client";
+import { PasswordInput } from "@/components/ui/password-input";
 
 const regStatusColors: Record<string, string> = {
   registered: "default",
@@ -116,7 +117,7 @@ export default function TrunksPage() {
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5"><Label>Username</Label><Input value={form.username} onChange={(e) => setForm({ ...form, username: e.target.value })} placeholder="SIP username" /></div>
-                <div className="space-y-1.5"><Label>Password</Label><Input type="password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} placeholder="SIP password" /></div>
+                <div className="space-y-1.5"><Label>Password</Label><PasswordInput value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} placeholder="SIP password" /></div>
               </div>
               <div className="space-y-1.5"><Label>Max Channels</Label><Input type="number" value={form.max_channels} onChange={(e) => setForm({ ...form, max_channels: e.target.value })} /></div>
             </div>
@@ -233,7 +234,7 @@ export default function TrunksPage() {
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5"><Label>Username</Label><Input value={editForm.username} onChange={(e) => setEditForm({ ...editForm, username: e.target.value })} placeholder="SIP username" /></div>
-              <div className="space-y-1.5"><Label>Password</Label><Input type="password" value={editForm.password} onChange={(e) => setEditForm({ ...editForm, password: e.target.value })} placeholder="Leave blank to keep current" /></div>
+              <div className="space-y-1.5"><Label>Password</Label><PasswordInput value={editForm.password} onChange={(e) => setEditForm({ ...editForm, password: e.target.value })} placeholder="Leave blank to keep current" /></div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">

--- a/editor/app/dashboard/[orgId]/users/page.tsx
+++ b/editor/app/dashboard/[orgId]/users/page.tsx
@@ -43,6 +43,7 @@ import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { showToast } from "@/components/ui/Toast";
 import { users, config as pbxConfig, type PbxUser } from "@/lib/pbx/client";
 import { SipQrDialog } from "@/components/users/SipQrDialog";
+import { PasswordInput } from "@/components/ui/password-input";
 
 export default function UsersPage() {
   const { orgId } = useParams<{ orgId: string }>();
@@ -182,7 +183,7 @@ export default function UsersPage() {
                 <div className="space-y-1.5"><Label>Email</Label><Input type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} placeholder="john@example.com" /></div>
               </div>
               <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5"><Label>Password</Label><Input type="text" autoComplete="off" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} placeholder="Min 6 chars" /></div>
+                <div className="space-y-1.5"><Label>Password</Label><PasswordInput autoComplete="off" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} placeholder="Min 6 chars" /></div>
                 <div className="space-y-1.5"><Label>Role</Label>
                   <Select value={form.role} onValueChange={(v) => setForm({ ...form, role: v as PbxUser["role"] })}>
                     <SelectTrigger><SelectValue /></SelectTrigger>
@@ -294,7 +295,7 @@ export default function UsersPage() {
                 </Select>
               </div>
             </div>
-            <div className="space-y-1.5"><Label>New Password (leave blank to keep)</Label><Input type="text" autoComplete="off" value={editForm.password} onChange={(e) => setEditForm({ ...editForm, password: e.target.value })} placeholder="Leave blank to keep current" /></div>
+            <div className="space-y-1.5"><Label>New Password (leave blank to keep)</Label><PasswordInput autoComplete="off" value={editForm.password} onChange={(e) => setEditForm({ ...editForm, password: e.target.value })} placeholder="Leave blank to keep current" /></div>
             <Separator />
             <div className="space-y-1.5"><Label>Call Routing</Label>
               <Select value={editForm.routing_type === "ai_agent" ? "ai_agent" : editForm.ring_target === "phone" ? "phone" : "sip"} onValueChange={(v) => {

--- a/editor/components/ui/password-input.tsx
+++ b/editor/components/ui/password-input.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export function PasswordInput(props: React.ComponentProps<typeof Input>) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        {...props}
+        type={show ? "text" : "password"}
+        className="pr-10"
+      />
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        tabIndex={-1}
+        onClick={() => setShow(!show)}
+        className="absolute right-2 top-1/2 -translate-y-1/2"
+      >
+        {show ? <EyeOff size={16} /> : <Eye size={16} />}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help us review your PR quickly.
-->

## Summary
<!-- What does this PR do? 1-3 sentences. -->

## Linked issue
Closes #20 

Closes #37

Added PasswordInput component to:
- User create dialog
- User edit dialog
- Trunk dialogs

Includes toggle visibility feature using Eye icon.

## Type of change
<!-- Check one -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## How to test
<!-- Steps a reviewer can follow to verify your changes work. -->

1.
2.
3.

## Screenshots (UI changes only)
<!-- Before / After screenshots for any editor UI changes. Delete this section if not applicable. -->

## Checklist
- [ ] This PR targets the `main` branch
- [ ] Code builds: `docker compose build <service>`
- [ ] Types pass: `cd editor && npx tsc --noEmit` (if touching editor)
- [ ] No secrets committed (`.env`, `firebase-sa-key.json`, API keys, etc.)
- [ ] Only shadcn/ui components used (if touching editor UI)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)

## Notes for the reviewer
<!-- Anything non-obvious? Tradeoffs you made? Leftover TODOs? -->
