### PR TITLE
feat(api): add helmet middlewawre for security headers

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
+        "helmet": "^8.1.0",
         "ioredis": "^5.7.0",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -2447,6 +2448,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-entities": {

--- a/api/package.json
+++ b/api/package.json
@@ -33,6 +33,7 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
+    "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -15,6 +15,7 @@ const axios = require('axios');
 const crypto = require('crypto');
 const swaggerUi = require('swagger-ui-express');
 const YAML = require('yamljs');
+const helmet = require('helmet');
 
 // Import database models
 const { sequelize } = require('./models');
@@ -34,6 +35,13 @@ const apiKeyRoutes = require('./routes/apiKeys');
 
 // Initialize Express app
 const app = express();
+
+app.use(helmet({
+  contentSecurityPolicy: false,  // Disable CSP for now — Swagger UI needs inline scripts
+  crossOriginEmbedderPolicy: false,
+  crossOriginResourcePolicy: { policy: 'cross-origin' },
+}));
+
 const PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || '127.0.0.1';
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help us review your PR quickly.
-->

## Summary
Add helmet middleware to the Express API to improve security by setting standard HTTP headers such as X-Content-Type-Options, X-Frame-Options, and Strict-Transport-Security.

## Linked issue
Closes #25 

## Type of change
<!-- Check one -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] CI / tooling
- [ ] Breaking change

## How to test
<!-- Steps a reviewer can follow to verify your changes work. -->

1. Run the API: npm start
2. Execute: curl -I http://localhost:3000/health
3. Verify security headers are present (e.g. X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security)
4. Open http://localhost:3000/api-docs and confirm Swagger UI loads correctly

## Screenshots (UI changes only)
<!-- Before / After screenshots for any editor UI changes. Delete this section if not applicable. -->

## Checklist
- [ ] This PR targets the `main` branch
- [ ] Code builds: `docker compose build <service>`
- [ ] Types pass: `cd editor && npx tsc --noEmit` (if touching editor)
- [x] No secrets committed (`.env`, `firebase-sa-key.json`, API keys, etc.)
- [ ] Only shadcn/ui components used (if touching editor UI)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)

## Notes for the reviewer
N/A
