### PR TITLE
Add .github/CODEOWNERS to auto-request reviews (#30)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS for astradial/astradial
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners — requested as reviewers on any PR
+*                           @harisuryaa @MUTHUMANIKANDAN11
+
+# API backend
+/api/                       @harisuryaa @MUTHUMANIKANDAN11
+
+# Editor frontend
+/editor/                    @harisuryaa
+
+# Asterisk PBX configs
+/asterisk/                  @harisuryaa
+
+# AI voice bot gateway
+/pipecat-flow/              @harisuryaa
+
+# Workflow engine
+/workflow-engine/           @harisuryaa
+
+# Docker & CI
+/docker-compose.yml         @harisuryaa @MUTHUMANIKANDAN11
+/.github/                   @harisuryaa @MUTHUMANIKANDAN11
+
+# Docs & community
+/*.md                       @harisuryaa


### PR DESCRIPTION
Closes #30.

Adds `.github/CODEOWNERS` using the suggested content from the issue, with one adjustment for the current repo layout:

- The issue's `/docs/` rule is omitted because the repo does not have a `docs/` directory yet. The `/*.md` rule still covers README, CONTRIBUTING, CODE_OF_CONDUCT, etc.

Everything else is verbatim from the issue: default owners on `*`, plus per-path routing for `/api/`, `/editor/`, `/asterisk/`, `/pipecat-flow/`, `/workflow-engine/`, `/docker-compose.yml`, and `/.github/`.

Branch protection toggle ("Require review from Code Owners") is up to maintainers — this PR just lays the file down.