### PR TITLE
fix: populate Organization defaults in beforeValidate

### DIFF
--- a/api/src/models/Organization.js
+++ b/api/src/models/Organization.js
@@ -81,20 +81,19 @@ module.exports = (sequelize) => {
     timestamps: true,
     underscored: true,
     hooks: {
-      beforeCreate: async (org) => {
-        // Generate API key if not provided
+      beforeValidate: async (org) => {
+        // allowNull:false validates before beforeCreate, so populate here.
         if (!org.api_key) {
           org.api_key = `org_${uuidv4().replace(/-/g, '')}`;
         }
-        // Generate API secret and hash it
+        if (!org.context_prefix) {
+          org.context_prefix = `org_${Date.now().toString(36)}`;
+        }
+      },
+      beforeCreate: async (org) => {
         if (!org.api_secret) {
           const secret = uuidv4();
           org.api_secret = await bcrypt.hash(secret, process.env.BCRYPT_ROUNDS || 12);
-        }
-        // Generate context prefix if not provided
-        if (!org.context_prefix) {
-          const timestamp = Date.now().toString(36);
-          org.context_prefix = `org_${timestamp}`;
         }
       },
       beforeUpdate: async (org) => {


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/request-org` 500'd with `notNull Violation: Organization.context_prefix cannot be null, notNull Violation: Organization.api_key cannot be null`.
- Sequelize runs `allowNull:false` validation **before** the `beforeCreate` hook, so the existing hook that generated `api_key` / `context_prefix` ran too late — validation rejected the row first.
- Move `api_key` + `context_prefix` generation into `beforeValidate`. Keep `api_secret` hashing in `beforeCreate` (callers always supply it; the hook only kicks in if absent).

## Test plan
- [x] Live patch deployed to `open.astradial.com` (`/opt/astradial-oss/api/src/models/Organization.js`) and `pm2 restart astradial-oss`
- [x] `POST /api/v1/auth/register` → HTTP 201
- [x] `POST /api/v1/auth/request-org` → HTTP 201, returns `org_id` + `pending_approval`
- [x] Probe rows cleaned up from `pbx_api_db.org_users` / `organizations`
- [ ] Reviewer to confirm no other call sites depend on `beforeCreate` ordering for these two fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)