### PR TITLE
chore(oss): remove Tata-gateway plumbing — BYO trunk only

### DIFF
--- a/api/src/routes/didPool.js
+++ b/api/src/routes/didPool.js
@@ -43,9 +43,6 @@ async function autoDeploy(orgId) {
       const org = await Organization.findByPk(orgId);
       if (org) await configService.deployOrganizationConfiguration(orgId, org.name);
     }
-    // Gateway routing is deployed inside deployOrganizationConfiguration,
-    // but also deploy standalone in case orgId is null
-    await configService.deployGatewayRouting();
     await configService.reloadAsteriskConfiguration();
     console.log('✅ Auto-deploy completed after DID change');
   } catch (e) {

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -5305,13 +5305,11 @@ app.use((req, res) => {
               }
               continue;
             }
-            // Determine direction. The original classifier relied on the
-            // channel name containing "trunk", which matches per-org outbound
-            // trunk endpoints (e.g. PJSIP/org_mna9x47k_trunk-...) but NOT the
-            // shared tata_gateway endpoint that receives calls from the NUC
-            // WireGuard tunnel on the staging cloud. Treat any CDR whose
-            // dcontext ends with "_incoming" as inbound as a safety net so
-            // staging's Tata-dispatch pipeline is picked up by the poller.
+            // Determine direction. The classifier looks at the channel name
+            // for "trunk" (matches per-org outbound trunk endpoints), but
+            // some inbound flows arrive on a non-trunk channel; treat any
+            // CDR whose dcontext ends with "_incoming" as inbound as a
+            // safety net so all inbound dispatch paths are picked up.
             let direction = 'internal';
             const ch = r.channel || '';
             const ctx = r.dcontext || '';

--- a/api/src/services/asterisk/configDeploymentService.js
+++ b/api/src/services/asterisk/configDeploymentService.js
@@ -50,13 +50,6 @@ class ConfigDeploymentService {
       // Update main configuration files with includes
       await this.ensureIncludesInMainConfigs(sanitizedOrgName);
 
-      // Deploy gateway inbound routing (Tata DID → org mapping)
-      try {
-        await this.deployGatewayRouting();
-      } catch (gwError) {
-        console.warn('⚠️  Warning: Failed to deploy gateway routing:', gwError.message);
-      }
-
       // Deploy Music on Hold configuration (system-wide)
       let mohDeployed = false;
       try {
@@ -562,75 +555,6 @@ exten => _X.,1,NoOp(Unrouted DID: \${EXTEN})
 
     } catch (error) {
       console.error('Error listing organization configurations:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Generate and deploy the Tata gateway inbound routing from the database.
-   * Replaces the static ext_tata_gateway.conf with DID→org routing derived
-   * from all assigned DIDs in the did_numbers table.
-   */
-  async deployGatewayRouting() {
-    try {
-      console.log('🌐 Generating gateway inbound routing from database...');
-
-      const assignedDids = await DidNumber.findAll({
-        where: { pool_status: 'assigned', status: 'active' },
-        include: [{ model: Organization, as: 'organization', attributes: ['id', 'name', 'context_prefix'] }],
-        order: [['number', 'ASC']],
-      });
-
-      const orgDids = {};
-      for (const did of assignedDids) {
-        if (!did.organization) continue;
-        const orgId = did.organization.id;
-        if (!orgDids[orgId]) orgDids[orgId] = { org: did.organization, dids: [] };
-        orgDids[orgId].dids.push(did);
-      }
-
-      let config = '';
-      config += '; Auto-generated Tata Gateway Inbound Routing\n';
-      config += `; Generated at: ${new Date().toISOString()}\n`;
-      config += '; DO NOT EDIT — regenerated on every config deploy\n\n';
-
-      config += '[tata-inbound]\n';
-      config += 'exten => _+9180659780XX,1,NoOp(Tata Inbound: ${EXTEN} from ${CALLERID(all)})\n';
-      config += 'same => n,Set(DID_CLEAN=${EXTEN:1})\n';
-      config += 'same => n,Goto(tata-did-route,${DID_CLEAN},1)\n\n';
-      config += 'exten => _9180659780XX,1,NoOp(Tata Inbound (no plus): ${EXTEN})\n';
-      config += 'same => n,Set(DID_CLEAN=${EXTEN})\n';
-      config += 'same => n,Goto(tata-did-route,${DID_CLEAN},1)\n\n';
-      config += 'exten => _X.,1,NoOp(Tata Inbound - Unmatched: ${EXTEN})\n';
-      config += 'same => n,Playback(number-not-in-service)\n';
-      config += 'same => n,Hangup()\n\n';
-
-      config += '[tata-did-route]\n';
-      config += '; DID-to-Organization routing (auto-generated from DB)\n';
-
-      for (const [, { org, dids }] of Object.entries(orgDids)) {
-        config += `\n; === ${org.name} (${org.context_prefix}_) ===\n`;
-        for (const did of dids) {
-          const cleanNum = did.number.replace(/[^0-9]/g, '');
-          config += `exten => ${cleanNum},1,Goto(${org.context_prefix}_incoming,${cleanNum},1)\n`;
-        }
-      }
-
-      config += '\n; Catch-all for unassigned DIDs\n';
-      config += 'exten => _X.,1,NoOp(Unassigned DID: ${EXTEN})\n';
-      config += 'same => n,Answer()\n';
-      config += 'same => n,Playback(number-not-in-service)\n';
-      config += 'same => n,Hangup()\n';
-
-      const gatewayFilePath = path.join(this.asteriskConfigPath, 'ext_tata_gateway.conf');
-      await this.writeConfigFile(gatewayFilePath, config);
-
-      const didCount = assignedDids.length;
-      const orgCount = Object.keys(orgDids).length;
-      console.log(`✅ Gateway routing deployed: ${didCount} DIDs across ${orgCount} orgs`);
-      return { success: true, didCount, orgCount };
-    } catch (error) {
-      console.error('❌ Error deploying gateway routing:', error);
       throw error;
     }
   }

--- a/api/src/services/asterisk/dialplanGenerator.js
+++ b/api/src/services/asterisk/dialplanGenerator.js
@@ -244,25 +244,12 @@ class DialplanGenerator {
     const subroutineName = `did_${cleanNumber}`;
     let routing = `; DID ${did.number} - ${did.description}\n`;
 
-    // Multiple patterns to catch the DID from different sources
+    // Match the DID in the two formats SIP providers commonly deliver.
     // Pattern 1: Direct number match (e.g., 15550123456)
     routing += `exten => ${cleanNumber},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
 
-    // Pattern 2: Number with + prefix
+    // Pattern 2: Number with + prefix (e.g., +15550123456)
     routing += `exten => +${cleanNumber},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
-
-    // Pattern 3: With country code 91 (NUC/Tata sends this)
-    routing += `exten => 91${cleanNumber},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
-
-    // Pattern 4: With +91 prefix
-
-    // Pattern 5 & 6: Without leading 0 — NUC sends +91{number without 0 prefix}
-    const numWithout0 = cleanNumber.replace(/^0+/, "");
-    if (numWithout0 !== cleanNumber) {
-      routing += `exten => 91${numWithout0},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
-      routing += `exten => +91${numWithout0},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
-    }
-    routing += `exten => +91${cleanNumber},1,Gosub(${org.context_prefix}_incoming_sub,${subroutineName},1(${did.id},${did.number}))\n`;
 
     routing += `exten => ${cleanNumber},n,Hangup()\n`;
     routing += `exten => +${cleanNumber},n,Hangup()\n\n`;

--- a/api/src/services/asterisk/sipTrunkService.js
+++ b/api/src/services/asterisk/sipTrunkService.js
@@ -82,9 +82,8 @@ class SipTrunkService {
     config += `transport=transport-${trunk.transport}\n`;
 
     // Authentication order: username/auth_username only (no IP matching).
-    // IP-based inbound matching is handled by the system-level tata_gateway
-    // endpoint. Per-org trunks are for OUTBOUND dialing — they should NOT
-    // create identify rules that collide with tata_gateway's IP match.
+    // Per-org trunks identify by SIP credentials, not source IP, so multiple
+    // orgs can use the same provider without identify-rule collisions.
     config += `identify_by=username,auth_username\n`;
 
     // Allow OPTIONS without authentication (for keepalive/health checks)
@@ -178,15 +177,14 @@ class SipTrunkService {
     }
 
     // Identify configuration — DISABLED for per-org trunks.
-    // The system-level tata_gateway endpoint handles all inbound IP
-    // matching from the gateway tunnel. Per-org
-    // trunks adding their own identify rules with a matching gateway IP
-    // would collide and steal inbound Tata calls, routing them into
-    // the wrong org context. This was a recurring prod bug.
+    // Per-org trunks identify by SIP credentials (username/auth_username),
+    // not by source IP. Adding identify rules here can cause collisions
+    // when two orgs share the same upstream provider IP, sending calls
+    // into the wrong org's context.
     //
-    // If a future use case needs per-org IP matching (e.g., a client
-    // with their own SIP trunk on a unique IP), add it as an explicit
-    // opt-in setting on the trunk, not a default for all peer2peer.
+    // If a future use case needs per-org IP matching (e.g., a client with
+    // a unique provider IP), add it as an explicit opt-in setting on the
+    // trunk, not a default for all peer2peer.
 
     return config;
   }

--- a/editor/app/dashboard/[orgId]/trunks/page.tsx
+++ b/editor/app/dashboard/[orgId]/trunks/page.tsx
@@ -88,7 +88,7 @@ export default function TrunksPage() {
             <DialogHeader><DialogTitle>Create Trunk</DialogTitle><DialogDescription>Connect a SIP carrier</DialogDescription></DialogHeader>
             <div className="space-y-4 py-2">
               <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5"><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Tata SIP" /></div>
+                <div className="space-y-1.5"><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="My SIP Provider" /></div>
                 <div className="space-y-1.5"><Label>Host</Label><Input value={form.host} onChange={(e) => setForm({ ...form, host: e.target.value })} placeholder="sip.provider.com" /></div>
               </div>
               <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary
- OSS distribution now ships **no Astradial-specific PSTN gateway routing**. Self-serve users get a multi-tenant SIP server (extensions, queues, internal calling) and add their own SIP trunk via the existing `POST /api/v1/trunks` UI.
- Inbound DIDs route only through per-org `pjsip_<org>.conf` and `ext_<org>.conf`, fed by the org's own trunk. No system-level gateway file is written by deploy.

## Changes
- `configDeploymentService.deployGatewayRouting()` removed (was generating `ext_tata_gateway.conf` with hardcoded Indian DID patterns).
- `deployOrganizationConfiguration()` no longer calls it.
- `routes/didPool.js#autoDeploy()` no longer calls it.
- `dialplanGenerator#generateDidRouting()` drops India-specific `91…` / `+91…` patterns; keeps generic `{number}` and `+{number}` (works for any provider).
- Comments referencing `tata_gateway` / "Tata-dispatch pipeline" rewritten to provider-neutral language.
- Trunk-form placeholder text updated from "Tata SIP" to "My SIP Provider".

## What's NOT changed (intentional)
- Prod (`editor.astradial.com` / `89.116.31.109`) Asterisk configs in `/etc/asterisk/*` — not in this repo, not affected.
- The `/api/v1/admin/dids` bulk-add tool (still defaults provider field to "Tata" — that's an admin convenience, not user-facing).
- DID-pool reselling concept in `routes/didPool.js` — separate decision; kept as-is.

## Test plan
- [ ] Manual: deploy an org with a BYO trunk, point a DID at it, verify inbound flow works.
- [ ] Manual: confirm `ext_tata_gateway.conf` is no longer written on a fresh deploy.
- [ ] Reviewer: confirm no other paths in the OSS code rely on the deleted method or India patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)