### PR TITLE
Add .dockerignore files for service builds

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.env
+.env.local
+.env.*.local
+*.log
+.git
+.gitignore
+README.md
+firebase-sa-key.json
+recordings/
+coverage/
+.DS_Store

--- a/editor/.dockerignore
+++ b/editor/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.env
+.env.local
+.env.*.local
+*.log
+.git
+.gitignore
+README.md
+.DS_Store
+coverage/

--- a/pipecat-flow/.dockerignore
+++ b/pipecat-flow/.dockerignore
@@ -1,0 +1,14 @@
+.venv
+__pycache__
+*.pyc
+.env
+.env.local
+*.log
+.git
+.gitignore
+.pytest_cache
+.mypy_cache
+.DS_Store
+gateway.db
+tests/
+docs/

--- a/workflow-engine/.dockerignore
+++ b/workflow-engine/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+.env.local
+*.log
+.git
+.gitignore
+README.md
+.DS_Store


### PR DESCRIPTION
## Summary
Added `.dockerignore` files for the service directories to reduce unnecessary Docker build context.

This PR adds `.dockerignore` files for:
- `api`
- `editor`
- `workflow-engine`
- `pipecat-flow`

The files exclude unnecessary local/development files such as `node_modules`, `.env`, logs, cache folders, `.git`, and other build artifacts.

## Linked issue
Closes #21

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] CI / tooling
- [ ] Breaking change

## How to test
1. Confirm the `.dockerignore` files exist in `api`, `editor`, `workflow-engine`, and `pipecat-flow`.
2. Run:
   ```bash
   docker compose build api --no-cache
   ```