### PR TITLE
fix(oss): bootstrap default org in setup.sh + plumb USE_FIREBASE through compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,9 @@ services:
       - ASTERISK_PJSIP_CONFIG_PATH=/etc/asterisk
       - INTERNAL_API_KEY=${INTERNAL_API_KEY:-internal-dev-key}
       - ASTRADIAL_MODE=${ASTRADIAL_MODE:-selfhosted}
+      # Auth provider: 'true' = Firebase mode (requires GOOGLE_APPLICATION_CREDENTIALS),
+      # anything else = local mode (api_key + api_secret via /api/v1/auth/login).
+      - USE_FIREBASE=${USE_FIREBASE:-false}
     depends_on:
       mariadb:
         condition: service_healthy
@@ -112,11 +115,16 @@ services:
         WORKFLOW_URL: ${NEXT_PUBLIC_WORKFLOW_URL:-http://workflow-engine:3002}
         GATEWAY_URL: ${NEXT_PUBLIC_GATEWAY_URL:-http://pipecat-flow:7860}
         ASTRADIAL_MODE: ${ASTRADIAL_MODE:-selfhosted}
+        # NEXT_PUBLIC_USE_FIREBASE must be set at BUILD time — Next.js
+        # bakes NEXT_PUBLIC_* into the static bundle. Default 'false' =
+        # OSS local mode (the OssLoginForm renders, api_key + api_secret).
+        NEXT_PUBLIC_USE_FIREBASE: ${NEXT_PUBLIC_USE_FIREBASE:-false}
     restart: unless-stopped
     ports:
       - "3001:3001"
     environment:
       - NEXT_PUBLIC_ASTRADIAL_MODE=${ASTRADIAL_MODE:-selfhosted}
+      - NEXT_PUBLIC_USE_FIREBASE=${NEXT_PUBLIC_USE_FIREBASE:-false}
       - NEXT_PUBLIC_GATEWAY_URL=http://pipecat-flow:7860
       - INTERNAL_API_KEY=${INTERNAL_API_KEY:-internal-dev-key}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -12,10 +12,15 @@ ARG PBX_URL=http://api:3000
 ARG WORKFLOW_URL=http://workflow-engine:3002
 ARG GATEWAY_URL=http://pipecat-flow:7860
 ARG ASTRADIAL_MODE=selfhosted
+# Auth provider — bake into the static bundle at build time.
+# 'false' (default) → OssLoginForm renders, login is api_key + api_secret.
+# 'true' → Firebase login UI, requires NEXT_PUBLIC_FIREBASE_* env vars.
+ARG NEXT_PUBLIC_USE_FIREBASE=false
 ENV NEXT_PUBLIC_PBX_URL=$PBX_URL
 ENV NEXT_PUBLIC_WORKFLOW_URL=$WORKFLOW_URL
 ENV NEXT_PUBLIC_GATEWAY_URL=$GATEWAY_URL
 ENV NEXT_PUBLIC_ASTRADIAL_MODE=$ASTRADIAL_MODE
+ENV NEXT_PUBLIC_USE_FIREBASE=$NEXT_PUBLIC_USE_FIREBASE
 
 RUN npm run build
 

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ echo ""
 
 # Check prerequisites
 command -v docker >/dev/null 2>&1 || { echo "Docker is required. Install: https://docker.com"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required (used to parse API responses)."; exit 1; }
 
 # ── Platform detection ──
 echo "Are you running on a Linux server or VPS? (y/n)"
@@ -22,9 +23,10 @@ IS_LINUX=${IS_LINUX:-n}
 if [ "$IS_LINUX" = "y" ] || [ "$IS_LINUX" = "Y" ]; then
   MODE="full"
 
-  # ── Admin credentials ──
+  # ── Operator account (for admin API + this script's bootstrap call) ──
   echo ""
-  echo "Set up your admin account:"
+  echo "Set up your operator account:"
+  echo "  (Used for admin-protected API endpoints + Asterisk AMI access.)"
   read -p "  Email [admin@example.com]: " ADMIN_EMAIL
   ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
   read -p "  Password [admin]: " ADMIN_PASSWORD
@@ -32,12 +34,23 @@ if [ "$IS_LINUX" = "y" ] || [ "$IS_LINUX" = "Y" ]; then
   read -p "  Name [Admin]: " ADMIN_NAME
   ADMIN_NAME=${ADMIN_NAME:-Admin}
 
+  # ── Organisation to bootstrap on first boot ──
+  echo ""
+  echo "Pick a name for your first organisation (3-50 chars, letters/digits/hyphens only):"
+  read -p "  Org name [MyAstradial]: " ORG_NAME
+  ORG_NAME=${ORG_NAME:-MyAstradial}
+
   SIP_HOST=$(hostname -I 2>/dev/null | awk '{print $1}' || ip route get 1 2>/dev/null | awk '{print $7;exit}' || echo "localhost")
   SIP_PORT="5060"
 
   # ── Write .env ──
   cat > .env << EOF
 ASTRADIAL_MODE=selfhosted
+
+# Auth mode — false: local (api_key + api_secret), true: Firebase project required
+USE_FIREBASE=false
+NEXT_PUBLIC_USE_FIREBASE=false
+
 DB_NAME=astradial
 DB_USER=astradial
 DB_PASSWORD=changeme
@@ -59,59 +72,97 @@ NEXT_PUBLIC_GATEWAY_URL=http://pipecat-flow:7860
 EOF
 
   echo ""
-  echo "[1/5] Building Docker images... (first run takes 3-5 minutes)"
+  echo "[1/6] Building Docker images... (first run takes 3-5 minutes)"
   docker compose build 2>&1 | while IFS= read -r line; do
     echo "$line" | grep -q " Built" && echo "  ✓ $(echo "$line" | sed 's/ Built//' | xargs) built"
   done
   echo "  ✓ All images built"
 
-  echo "[2/5] Starting database..."
+  echo "[2/6] Starting database..."
   docker compose up -d mariadb redis 2>&1 >/dev/null
   for i in $(seq 1 30); do
-    docker compose exec mariadb mariadb -u astradial -pchangeme -e "SELECT 1" >/dev/null 2>&1 && break
+    docker compose exec -T mariadb mariadb -u astradial -pchangeme -e "SELECT 1" >/dev/null 2>&1 && break
     printf "\r  ⏳ Waiting... (%s/30)" "$i"; sleep 2
   done
   echo ""; echo "  ✓ Database ready"
 
-  echo "[3/5] Starting Asterisk PBX..."
+  echo "[3/6] Starting Asterisk PBX..."
   docker compose up -d asterisk 2>&1 >/dev/null; sleep 3
   echo "  ✓ Asterisk started"
 
-  echo "[4/5] Starting API, Dashboard, and AI Gateway..."
+  echo "[4/6] Starting API, Dashboard, and AI Gateway..."
   docker compose up -d api editor workflow-engine pipecat-flow 2>&1 >/dev/null
-  for i in $(seq 1 30); do
+  for i in $(seq 1 60); do
     curl -s http://localhost:8000/health >/dev/null 2>&1 && break
-    printf "\r  ⏳ Starting... (%s/30)" "$i"; sleep 2
+    printf "\r  ⏳ Starting... (%s/60)" "$i"; sleep 2
   done
   echo ""; echo "  ✓ API ready"
 
-  echo "[5/5] Finishing..."
-  for i in $(seq 1 15); do
+  echo "[5/6] Bootstrapping your first organisation..."
+  # Calls the admin-protected POST /api/v1/organizations. The endpoint
+  # generates a fresh api_key + api_secret pair for this org; the api_secret
+  # is returned PLAINTEXT in the response (the DB stores only the bcrypt
+  # hash). This is the only window where we can print the secret — save it.
+  ORG_RESPONSE=$(curl -s -X POST http://localhost:8000/api/v1/organizations \
+    -H 'Content-Type: application/json' \
+    -d "{\"admin_username\":\"admin\",\"admin_password\":\"${ADMIN_PASSWORD}\",\"name\":\"${ORG_NAME}\",\"contact_info\":{\"email\":\"${ADMIN_EMAIL}\"}}" 2>/dev/null)
+  ORG_API_KEY=$(echo "$ORG_RESPONSE" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("api_key",""))
+except: print("")' 2>/dev/null)
+  ORG_API_SECRET=$(echo "$ORG_RESPONSE" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("api_secret",""))
+except: print("")' 2>/dev/null)
+  ORG_ID=$(echo "$ORG_RESPONSE" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("id",""))
+except: print("")' 2>/dev/null)
+
+  if [ -z "$ORG_API_KEY" ] || [ -z "$ORG_API_SECRET" ]; then
+    echo ""
+    echo "  ⚠️  Organisation bootstrap failed. API response was:"
+    echo "$ORG_RESPONSE" | head -c 500
+    echo ""
+    echo "  You can still log in by creating an org manually:"
+    echo "    curl -X POST http://localhost:8000/api/v1/organizations \\"
+    echo "      -H 'Content-Type: application/json' \\"
+    echo "      -d '{\"admin_username\":\"admin\",\"admin_password\":\"${ADMIN_PASSWORD}\",\"name\":\"YourOrg\"}'"
+    ORG_API_KEY="(see manual command above)"
+    ORG_API_SECRET="(see manual command above)"
+  else
+    echo "  ✓ Organisation '${ORG_NAME}' created"
+  fi
+
+  echo "[6/6] Waiting for dashboard..."
+  for i in $(seq 1 30); do
     curl -s http://localhost:3001 >/dev/null 2>&1 && break; sleep 2
   done
   echo "  ✓ Dashboard ready"
 
-  # Deploy config
-  TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/auth/user-login \
-    -H 'Content-Type: application/json' \
-    -d "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\"}" 2>/dev/null \
-    | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null)
-  if [ -n "$TOKEN" ] && [ "$TOKEN" != "" ]; then
-    curl -s -X POST http://localhost:8000/api/v1/config/deploy -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1
-    echo "  ✓ Config deployed"
-  fi
-
   echo ""
-  echo "╔══════════════════════════════════════════════════════════╗"
-  echo "║  Astradial is ready!                                     ║"
-  echo "║                                                          ║"
-  echo "║  Dashboard:  http://localhost:3001                        ║"
-  echo "║  Login:      ${ADMIN_EMAIL} / ${ADMIN_PASSWORD}"
-  echo "║  SIP:        ${SIP_HOST}:${SIP_PORT}"
-  echo "║                                                          ║"
-  echo "║  Admin tab → create org → Users → create extension      ║"
-  echo "║  → register Zoiper → make calls                          ║"
-  echo "╚══════════════════════════════════════════════════════════╝"
+  echo "════════════════════════════════════════════════════════════════"
+  echo "  Astradial is ready!"
+  echo "════════════════════════════════════════════════════════════════"
+  echo ""
+  echo "  Dashboard:        http://localhost:3001"
+  echo "  SIP server:       ${SIP_HOST}:${SIP_PORT}"
+  echo ""
+  echo "  YOUR LOGIN CREDENTIALS — save these somewhere safe NOW:"
+  echo ""
+  echo "    API key:        ${ORG_API_KEY}"
+  echo "    API secret:     ${ORG_API_SECRET}"
+  echo ""
+  echo "    Org name:       ${ORG_NAME}"
+  echo "    Org id:         ${ORG_ID}"
+  echo ""
+  echo "  These won't be shown again. The API secret is only printed"
+  echo "  once at org creation — the database stores only its bcrypt hash."
+  echo ""
+  echo "  Open the dashboard → paste the API key + secret into the login"
+  echo "  form → then go to Users to add extensions, queues, etc."
+  echo ""
+  echo "  Want Firebase / Google sign-in instead? Set"
+  echo "  USE_FIREBASE=true + NEXT_PUBLIC_USE_FIREBASE=true in .env"
+  echo "  and add your NEXT_PUBLIC_FIREBASE_* env vars."
+  echo "════════════════════════════════════════════════════════════════"
 
 else
   MODE="cloud"
@@ -130,6 +181,11 @@ else
   # ── Write .env ──
   cat > .env << EOF
 ASTRADIAL_MODE=cloud
+
+# Auth mode — false: local (api_key + api_secret), true: Firebase project required
+USE_FIREBASE=false
+NEXT_PUBLIC_USE_FIREBASE=false
+
 NEXT_PUBLIC_PBX_URL=${PBX_URL}
 SIP_HOST=${SIP_HOST}
 SIP_PORT=${SIP_PORT}
@@ -154,18 +210,18 @@ EOF
   echo "  ✓ Dashboard ready"
 
   echo ""
-  echo "╔══════════════════════════════════════════════════════════╗"
-  echo "║  Astradial is ready!                                     ║"
-  echo "║                                                          ║"
-  echo "║  Dashboard:  http://localhost:3001                        ║"
-  echo "║  API:        ${PBX_URL}"
-  echo "║  SIP:        ${SIP_HOST}:${SIP_PORT}"
-  echo "║                                                          ║"
-  echo "║  Login with your Astradial Cloud credentials.            ║"
-  echo "║  Create extensions → register Zoiper → make calls.      ║"
-  echo "║                                                          ║"
-  echo "║  Don't have credentials? Email cats@astradial.com        ║"
-  echo "╚══════════════════════════════════════════════════════════╝"
+  echo "════════════════════════════════════════════════════════════════"
+  echo "  Astradial is ready!"
+  echo "════════════════════════════════════════════════════════════════"
+  echo ""
+  echo "  Dashboard:    http://localhost:3001"
+  echo "  API:          ${PBX_URL}"
+  echo "  SIP:          ${SIP_HOST}:${SIP_PORT}"
+  echo ""
+  echo "  Log in with the api_key + api_secret you received when your"
+  echo "  Astradial Cloud org was provisioned."
+  echo "  Don't have credentials? Email cats@astradial.com"
+  echo "════════════════════════════════════════════════════════════════"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

The USE_FIREBASE flag merged in #53 defaults to local-mode auth (api_key + api_secret), but `setup.sh` still tried to authenticate via `/api/v1/auth/user-login` — which is the Firebase-only route (now returns 503 when `USE_FIREBASE!=true`). Result: a fresh `./setup.sh` install boots the stack successfully but the user has no working login path — the OssLoginForm asks for api_key + api_secret that don't yet exist.

This PR fixes the bootstrap flow.

## Changes

### `setup.sh` (linux/VPS branch)

- Generated `.env` now sets `USE_FIREBASE=false` + `NEXT_PUBLIC_USE_FIREBASE=false` (explicit, matches the OSS-native default).
- **New step** between API-ready and dashboard-ready: `POST /api/v1/organizations` (admin-credential-protected) to bootstrap a default org. User can name it; defaults to `MyAstradial`.
- Parses the response and prints the `api_key` + `api_secret` prominently to the user — this is the only window where the plaintext secret is visible (DB stores only the bcrypt hash).
- Updated final "Astradial is ready!" banner with the actual login flow: paste those credentials into the OssLoginForm at `http://localhost:3001`.
- Removed the now-broken `/auth/user-login` call.
- Bumped step count from 5 → 6.
- Added `python3` to the prerequisites check (used to parse the JSON response).

### `setup.sh` (Mac/Windows cloud mode)

- Also writes `USE_FIREBASE=false` to `.env` so the editor renders the OssLoginForm. Cloud users log in with the api_key + api_secret they got when their Astradial Cloud org was provisioned.

### `docker-compose.yml`

- `api` service: explicit `USE_FIREBASE=${USE_FIREBASE:-false}` env var.
- `editor` service: `NEXT_PUBLIC_USE_FIREBASE` as both a `build.args` (Next.js bakes `NEXT_PUBLIC_*` into the static bundle at build time) and a runtime `environment` entry (for SSR consistency).

### `editor/Dockerfile`

- New `ARG NEXT_PUBLIC_USE_FIREBASE=false` + `ENV` passthrough before `npm run build` — the static client bundle now reflects the flag.

## Acceptance flow (post-merge)

```
git clone github.com/astradial/astradial && cd astradial
./setup.sh         # answers: y (Linux/VPS), email, password, name, org name
# ↓ 3-5 min build, services start, default org bootstrapped
# ↓ setup prints api_key + api_secret in the final banner

# user copies the printed credentials
open http://localhost:3001
# OssLoginForm renders → paste api_key + api_secret → click Sign in → dashboard
```

## Test plan

- [x] `bash -n setup.sh` — syntax OK
- [x] `docker compose config --quiet` — compose file valid
- [x] Python heredoc extraction tested inline (parses example JSON correctly)
- [ ] Reviewer: full `./setup.sh` run on a clean machine — verify org bootstrap, credential print, dashboard login end-to-end
- [ ] Reviewer: smoke test the Firebase path (set `USE_FIREBASE=true` + Firebase env vars before `setup.sh`) — verify the OSS flow still defers cleanly

## Follow-ups

- (Not in this PR) Make `setup.sh` more robust if a previous org with the same name exists (currently errors with 409)
- (Not in this PR) Move the `python3` parsing to use a shell-native JSON parser like `jq` if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)