### PR TITLE
fix(editor): remove orphan grand_estancia_ticketing import

### DIFF
--- a/editor/lib/examples/index.ts
+++ b/editor/lib/examples/index.ts
@@ -1,5 +1,4 @@
 import foodOrdering from "./food_ordering.json";
-import grandEstanciaTicketing from "./grand_estancia_ticketing.json";
 import minimal from "./minimal.json";
 import podcastInterview from "./podcast_interview.json";
 
@@ -7,5 +6,4 @@ export const EXAMPLES = [
   { id: "minimal", name: "Minimal", json: minimal },
   { id: "food_ordering", name: "Food Ordering (Simple)", json: foodOrdering },
   { id: "podcast_interview", name: "Podcast Interview", json: podcastInterview },
-  { id: "grand_estancia_ticketing", name: "Grand Estancia Ticketing (Gemini Live)", json: grandEstanciaTicketing },
 ];


### PR DESCRIPTION
Editor build was failing:

```
Module not found: Can't resolve './grand_estancia_ticketing.json'
  ./lib/examples/index.ts:2:1
```

The file was scrubbed in the OSS sync (customer-specific) but the dangling import remained. Removes both the import + the EXAMPLES entry. Three non-customer examples remain.