### PR TITLE
fix(editor): queues page addMembers→addMember (TS build error)

### DIFF
--- a/editor/app/dashboard/[orgId]/queues/page.tsx
+++ b/editor/app/dashboard/[orgId]/queues/page.tsx
@@ -601,7 +601,7 @@ export default function QueuesPage() {
               <Select key={`add-member-${editingQueue?.members?.length ?? 0}`} onValueChange={async (userId) => {
                 if (!editingQueue) return;
                 try {
-                  await queues.addMembers(editingQueue.id, [userId]);
+                  await queues.addMember(editingQueue.id, userId);
                   showToast("Member added", "success");
                   await loadAll();
                   const updated = await queues.get(editingQueue.id);


### PR DESCRIPTION
OSS queues page called `addMembers` (plural, doesn't exist) — TypeScript build failed. Switched to the correct `addMember` (singular) which matches the departments page.