### PR TITLE
fix(api): migration runner handles .js + .sql interleaved chronologically

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -17,21 +17,10 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
-# Run Sequelize migrations
+# Run all migrations (.js + .sql) in timestamp order — single script,
+# fails fast, records to SequelizeMeta.
 echo "Running migrations..."
-npx sequelize-cli db:migrate 2>/dev/null || echo "Sequelize migrations done"
-
-# Run SQL migrations (for tables not covered by Sequelize)
-for f in database/migrations/*.sql; do
-  if [ -f "$f" ]; then
-    echo "Running SQL: $f"
-    node -e "
-      const m=require('mariadb'),fs=require('fs');
-      const p=m.createPool({host:process.env.DB_HOST||'localhost',port:parseInt(process.env.DB_PORT)||3306,user:process.env.DB_USER||'astradial',password:process.env.DB_PASSWORD||'changeme',database:process.env.DB_NAME||'astradial',connectionLimit:1,multipleStatements:true});
-      p.getConnection().then(async c=>{try{await c.query(fs.readFileSync('$f','utf8'))}catch(e){if(!e.message.includes('already exists'))console.error(e.message)}finally{c.release();await p.end();process.exit(0)}}).catch(e=>{console.error(e.message);process.exit(0)});
-    " 2>/dev/null || true
-  fi
-done
+node scripts/run-migrations.js
 
 # Seed default admin on first boot
 echo "Checking seed..."

--- a/api/scripts/run-migrations.js
+++ b/api/scripts/run-migrations.js
@@ -1,33 +1,30 @@
 #!/usr/bin/env node
 /**
- * Run pending Sequelize migrations during deploy, without requiring
- * sequelize-cli (which isn't installed in production — npm ci --omit=dev
- * skips devDependencies).
+ * Run pending DB migrations during deploy.
  *
- * Mirrors what sequelize-cli's `db:migrate` does on the happy path:
- *   1. Reads every file in `database/migrations/`.
- *   2. Reads the names already recorded in `SequelizeMeta`.
- *   3. For each file not yet recorded, runs `up(queryInterface, Sequelize)`
- *      and inserts the filename into `SequelizeMeta` afterward.
- *   4. Exits 0 if every pending migration succeeded; non-zero if any failed.
+ * Handles BOTH file types in timestamp order:
+ *   - .js  — Sequelize-style modules with `up(queryInterface, Sequelize)`
+ *   - .sql — raw SQL run via `sequelize.query()` (supports multi-statement)
  *
- * Runs in alphabetical order by filename. Sequelize CLI's default convention
- * is a date-prefixed name (`20260513120000-add-user-failover-fields.js`) so
- * alphabetical order = chronological order.
+ * Order = lexicographic by filename. Sequelize CLI's default
+ * `YYYYMMDDHHMMSS-name.ext` convention makes alphabetical = chronological,
+ * so a .sql file dated 2026-04-12 runs BEFORE a .js file dated 2026-04-13
+ * even though they're different file types. That's the whole point —
+ * interleaving fixes the original bug where all .sql ran after all .js,
+ * causing .js migrations that depend on .sql-added columns to fail
+ * silently in production deploys.
  *
- * The script is idempotent: re-running it is a no-op once the DB is at
- * head. Failures stop the script — a partial migration leaves the
- * remaining migrations pending, and the same deploy run will surface the
- * error so the operator sees what broke before the new code reloads.
+ * Each filename is recorded in `SequelizeMeta` after a successful apply,
+ * so re-runs are idempotent. Failures stop the script — partial state is
+ * left in place for the operator to debug, and the deploy workflow exits
+ * non-zero so the new code doesn't reload over a broken DB.
  *
- * Called from the deploy workflows AFTER `npm ci --omit=dev` (so the
- * `sequelize` package is present) and BEFORE `pm2 reload`. If a migration
- * fails, pm2 is NOT reloaded — the old code keeps serving traffic while
- * the operator debugs.
+ * Doesn't require sequelize-cli (which isn't always present in production
+ * — `npm ci --omit=dev` skips devDependencies).
  *
- * Designed to be called from inside `/app` (production), but
- * works from any CWD as long as `database/migrations/` and the Sequelize
- * config are reachable relative to the script path.
+ * Designed to be called from inside `/app/api` or wherever the
+ * working directory has `database/migrations/` reachable. Locates files
+ * relative to its own path so cwd doesn't matter.
  */
 
 'use strict';
@@ -38,6 +35,48 @@ const path = require('path');
 const SCRIPT_DIR = __dirname;
 const API_ROOT = path.resolve(SCRIPT_DIR, '..');
 const MIGRATIONS_DIR = path.join(API_ROOT, 'database', 'migrations');
+
+async function applyJsMigration(file, qi, Sequelize) {
+  const migration = require(path.join(MIGRATIONS_DIR, file));
+  if (typeof migration.up !== 'function') {
+    throw new Error(`Migration ${file} has no up() function`);
+  }
+  await migration.up(qi, Sequelize);
+}
+
+async function applySqlMigration(file, sequelize) {
+  const sqlPath = path.join(MIGRATIONS_DIR, file);
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+
+  // Split on `;` at end-of-statement. Naive — would break on semicolons
+  // inside string literals. Our SQL migrations don't have any.
+  const statements = sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  for (const stmt of statements) {
+    // Skip lines that are pure SQL comments
+    const meaningful = stmt.replace(/^\s*--[^\n]*\n?/gm, '').trim();
+    if (meaningful === '') continue;
+    try {
+      await sequelize.query(stmt);
+    } catch (e) {
+      // `ADD COLUMN IF NOT EXISTS` etc. throw on re-run on some MariaDB
+      // versions; tolerate well-known idempotency-related errors so
+      // re-runs are safe.
+      if (
+        e.message.match(/already exists/i) ||
+        e.message.match(/Duplicate column/i) ||
+        e.message.match(/Duplicate key/i)
+      ) {
+        console.log(`      (skipping — already applied: ${e.message.slice(0, 80)})`);
+        continue;
+      }
+      throw new Error(`SQL statement failed in ${file}: ${e.message}\n  Statement: ${stmt.slice(0, 200)}`);
+    }
+  }
+}
 
 async function main() {
   const sequelize = require(path.join(API_ROOT, 'src', 'config', 'database'));
@@ -51,8 +90,9 @@ async function main() {
     ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
   );
 
+  // Discover BOTH .js and .sql migrations, sort chronologically.
   const allFiles = fs.readdirSync(MIGRATIONS_DIR)
-    .filter((f) => f.endsWith('.js'))
+    .filter((f) => f.endsWith('.js') || f.endsWith('.sql'))
     .sort();
 
   const applied = new Set(
@@ -71,11 +111,11 @@ async function main() {
   console.log(`Running ${pending.length} pending migration${pending.length === 1 ? '' : 's'}:`);
   for (const file of pending) {
     console.log(`  → ${file}`);
-    const migration = require(path.join(MIGRATIONS_DIR, file));
-    if (typeof migration.up !== 'function') {
-      throw new Error(`Migration ${file} has no up() function`);
+    if (file.endsWith('.js')) {
+      await applyJsMigration(file, qi, Sequelize);
+    } else {
+      await applySqlMigration(file, sequelize);
     }
-    await migration.up(qi, Sequelize);
     await sequelize.query('INSERT INTO SequelizeMeta (name) VALUES (:n)', {
       replacements: { n: file }
     });


### PR DESCRIPTION
Unified migration runner — `node scripts/run-migrations.js` now handles BOTH file types in YYYYMMDDHHMMSS order. Caught on a fresh OSS VPS where the broken ordering left ~22 of 36 migrations un-applied; bootstrap org-creation failed with 'Unknown column ticket_alerts_enabled'. entrypoint.sh simplified to a single call.