### PR TITLE
fix(api): migration runner tolerates idempotency errors (.js path)

### DIFF
--- a/api/scripts/run-migrations.js
+++ b/api/scripts/run-migrations.js
@@ -41,7 +41,24 @@ async function applyJsMigration(file, qi, Sequelize) {
   if (typeof migration.up !== 'function') {
     throw new Error(`Migration ${file} has no up() function`);
   }
-  await migration.up(qi, Sequelize);
+  try {
+    await migration.up(qi, Sequelize);
+  } catch (e) {
+    // Tolerate well-known idempotency errors — the same migration may have
+    // been applied via a different path (e.g. Sequelize model auto-sync
+    // creating columns) or the operator already ran it manually. Keep
+    // recording the filename in SequelizeMeta so future runs skip it.
+    if (
+      e.message.match(/already exists/i) ||
+      e.message.match(/Duplicate column/i) ||
+      e.message.match(/Duplicate key/i) ||
+      e.message.match(/Duplicate entry/i)
+    ) {
+      console.log(`      (skipping — already applied: ${e.message.slice(0, 80)})`);
+      return;
+    }
+    throw e;
+  }
 }
 
 async function applySqlMigration(file, sequelize) {


### PR DESCRIPTION
Caught on full-stack OSS boot. The did-pool migration tried to addColumn that already exists (likely from Sequelize model auto-sync). Migration runner now skips well-known idempotency errors (same as .sql path) so a fresh boot doesn't stall at migration 17/36.