### PR TITLE
feat(api): bootstrap-or-migrate strategy (sync on fresh, migrate on existing)

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -17,10 +17,13 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
-# Run all migrations (.js + .sql) in timestamp order — single script,
-# fails fast, records to SequelizeMeta.
-echo "Running migrations..."
-node scripts/run-migrations.js
+# Bootstrap-or-migrate:
+#  - Fresh install (empty SequelizeMeta) → sync schema from Sequelize models
+#    then mark all migrations as applied. Avoids the 36-migration historical
+#    chain that's brittle on fresh DBs.
+#  - Existing install → run pending migrations via scripts/run-migrations.js.
+echo "Bootstrapping schema..."
+node scripts/bootstrap-or-migrate.js
 
 # Seed default admin on first boot
 echo "Checking seed..."

--- a/api/scripts/bootstrap-or-migrate.js
+++ b/api/scripts/bootstrap-or-migrate.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Bootstrap-or-migrate — the single entry point for getting the DB
+ * schema into the right state at api boot.
+ *
+ * Strategy:
+ *  - FRESH install (SequelizeMeta missing or empty): use sequelize.sync()
+ *    to create every table from the model definitions. This is the
+ *    "source of truth" for OSS users who don't need the historical
+ *    migration chain. After sync, every existing migration filename is
+ *    recorded in SequelizeMeta so future deploys don't try to re-apply
+ *    them (which would fail with Duplicate-column / Foreign-key errors).
+ *
+ *  - EXISTING install (SequelizeMeta has rows): delegate to the regular
+ *    run-migrations.js so new migrations land normally.
+ *
+ * Why this hybrid rather than always-migrate:
+ *  Migrations were originally written for an internal SaaS that evolved
+ *  incrementally — they assume earlier ones already applied, sometimes
+ *  reference columns added by Sequelize sync, sometimes update tables
+ *  that don't exist on fresh installs. For a clean OSS docker-compose
+ *  boot, asking 36 historical migrations to land in order on an empty
+ *  DB is brittle. sync() takes the model definitions (which ARE the
+ *  current schema) and just creates them all.
+ *
+ *  Existing deployments (e.g. anyone upgrading from a hosted snapshot
+ *  or a previous OSS install) still get the proper migration path.
+ *
+ * Idempotent: re-runs are no-ops once SequelizeMeta is populated.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const SCRIPT_DIR = __dirname;
+const API_ROOT = path.resolve(SCRIPT_DIR, '..');
+const MIGRATIONS_DIR = path.join(API_ROOT, 'database', 'migrations');
+
+async function isFreshInstall(sequelize) {
+  try {
+    const rows = await sequelize.query(
+      'SELECT COUNT(*) AS n FROM SequelizeMeta',
+      { type: sequelize.QueryTypes.SELECT },
+    );
+    const count = Number(rows[0].n);
+    return count === 0;
+  } catch (e) {
+    // Table doesn't exist → fresh
+    return true;
+  }
+}
+
+async function markAllMigrationsApplied(sequelize) {
+  await sequelize.query(
+    'CREATE TABLE IF NOT EXISTS SequelizeMeta (' +
+    '  name VARCHAR(255) NOT NULL PRIMARY KEY' +
+    ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+  );
+
+  const files = fs.readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.js') || f.endsWith('.sql'))
+    .sort();
+
+  for (const f of files) {
+    try {
+      await sequelize.query(
+        'INSERT INTO SequelizeMeta (name) VALUES (:n)',
+        { replacements: { n: f } },
+      );
+    } catch (e) {
+      // Duplicate primary key = already recorded; ignore.
+      if (!e.message.match(/Duplicate/i)) throw e;
+    }
+  }
+  console.log(`✓ Recorded ${files.length} migration filenames in SequelizeMeta.`);
+}
+
+function runMigrationsScript() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'node',
+      [path.join(SCRIPT_DIR, 'run-migrations.js')],
+      { stdio: 'inherit', cwd: API_ROOT },
+    );
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`run-migrations.js exited ${code}`));
+    });
+  });
+}
+
+async function main() {
+  const sequelize = require(path.join(API_ROOT, 'src', 'config', 'database'));
+  const { syncDatabase } = require(path.join(API_ROOT, 'src', 'models'));
+
+  const fresh = await isFreshInstall(sequelize);
+
+  if (fresh) {
+    console.log('Fresh install detected (SequelizeMeta empty/missing).');
+    console.log('Creating schema from Sequelize models...');
+    await syncDatabase(false);
+    await markAllMigrationsApplied(sequelize);
+    console.log('✓ Bootstrap complete.');
+    await sequelize.close();
+    return;
+  }
+
+  console.log('Existing install detected. Running pending migrations...');
+  await sequelize.close();
+  await runMigrationsScript();
+}
+
+main().catch((err) => {
+  console.error('✗ Bootstrap/migrate failed:', err.message);
+  if (err.stack) console.error(err.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Fresh OSS installs were hitting migration errors at ~20/36. Strategy pivot: on a fresh DB, use `sequelize.sync()` to create tables from model definitions (the actual schema source of truth), then mark all migrations as applied. Existing installs still get the proper migration path. Verified on Ubuntu 24.04 VPS.