### PR TITLE
fix(oss): pipecat-flow uvicorn dep + postgres service for workflow-engine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,27 @@ services:
     networks:
       - astradial
 
+  # PostgreSQL — backs workflow-engine only. The astrapbx api uses
+  # mariadb; we run both because the workflow service was originally
+  # written against Postgres and ports cleanly. Self-bootstraps its
+  # tables on first boot via workflow-engine/src/db.js.
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${PG_DATABASE:-workflow_db}
+      POSTGRES_USER: ${PG_USER:-workflow}
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-workflow_secure}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER:-workflow} -d ${PG_DATABASE:-workflow_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - astradial
+
   asterisk:
     build: ./asterisk
     restart: unless-stopped
@@ -150,9 +171,19 @@ services:
       - API_URL=http://api:8000
       - INTERNAL_API_KEY=${INTERNAL_API_KEY:-internal-dev-key}
       - PORT=3002
+      # Workflow service uses Postgres (separate from the astrapbx mariadb)
+      - PG_HOST=postgres
+      - PG_PORT=5432
+      - PG_USER=${PG_USER:-workflow}
+      - PG_PASSWORD=${PG_PASSWORD:-workflow_secure}
+      - PG_DATABASE=${PG_DATABASE:-workflow_db}
     depends_on:
-      - api
-      - redis
+      api:
+        condition: service_started
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_healthy
     networks:
       - astradial
 
@@ -182,6 +213,7 @@ services:
 
 volumes:
   mariadb_data:
+  postgres_data:
   asterisk_config:
   asterisk_recordings:
 

--- a/pipecat-flow/pyproject.toml
+++ b/pipecat-flow/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "gunicorn>=23.0.0",
     "aiohttp>=3.11.0",
+    # Web stack — gateway/main.py runs a FastAPI app served by uvicorn
+    # (directly via `python -m gateway.main` in dev; via gunicorn with
+    # uvicorn workers in prod). Both invocations need these installed.
+    "uvicorn[standard]>=0.30.0",
+    "fastapi>=0.115.0",
 ]
 
 [project.urls]

--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,11 @@ DB_NAME=astradial
 DB_USER=astradial
 DB_PASSWORD=changeme
 DB_ROOT_PASSWORD=changeme
+
+# Postgres (used only by workflow-engine; separate from the astrapbx mariadb)
+PG_DATABASE=workflow_db
+PG_USER=workflow
+PG_PASSWORD=$(openssl rand -hex 16 2>/dev/null || echo "workflow_secure")
 JWT_SECRET=$(openssl rand -hex 32 2>/dev/null || echo "change-this-secret")
 INTERNAL_API_KEY=$(openssl rand -hex 16 2>/dev/null || echo "change-this-key")
 ADMIN_EMAIL=${ADMIN_EMAIL}


### PR DESCRIPTION
Two services were restart-looping on fresh OSS boot:

**pipecat-flow** — `gateway/main.py` imports uvicorn but pyproject.toml only listed gunicorn. Added `uvicorn[standard]` + `fastapi` to dependencies.

**workflow-engine** — uses Postgres (`PG_*` env vars in `workflow-engine/src/db.js`), but docker-compose only had MariaDB. Added a postgres:16-alpine service with healthcheck + wired env. Self-bootstraps schema on first boot via CREATE TABLE IF NOT EXISTS.

setup.sh now generates a random PG_PASSWORD.