### PR TITLE
fix(security): bind MariaDB + Redis to 127.0.0.1; random passwords in setup.sh

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,108 @@
+# Security
+
+If you've deployed an OSS Astradial instance, read this. The defaults
+are now safe, but earlier versions of `docker-compose.yml` and
+`setup.sh` had two issues that need explicit upgrade steps.
+
+## Reporting vulnerabilities
+
+If you find a security issue please email **security@astradial.in**
+with a description and reproduction steps. We aim to acknowledge
+within 1 business day. Please don't open a public issue or PR for
+unpatched vulnerabilities.
+
+## What changed (2026-05-28)
+
+A Skylink-OSS deployment was hit by an automated MariaDB ransomware
+scanner. Root cause + the fixes that landed in the repo:
+
+| Vulnerability | Fix |
+|---|---|
+| `docker-compose.yml` published MariaDB on `0.0.0.0:3307` | Now binds to `127.0.0.1:3307:3306` |
+| `docker-compose.yml` published Redis on `0.0.0.0:6379` | Now binds to `127.0.0.1:6379:6379` |
+| `setup.sh` defaulted `DB_PASSWORD` and `DB_ROOT_PASSWORD` to the dictionary word `changeme` | Now generates a 24-byte random hex string per password |
+
+### Why docker-compose `ports:` defaults are dangerous
+
+When you write `ports: - "3307:3306"`, Docker writes iptables rules
+directly to its `DOCKER` and `DOCKER-USER` chains. These run **before**
+UFW's `INPUT` chain, so the port becomes reachable from the public
+internet even when `ufw status` shows no rule for it. The phrase to
+remember: **UFW doesn't see Docker port forwards.**
+
+This is documented but easy to miss:
+https://docs.docker.com/network/iptables/
+
+## Upgrading an existing deployment
+
+If you deployed before this commit you may be exposed. Check:
+
+```bash
+# From OUTSIDE the box, scan for exposed DB ports:
+nmap -sT -Pn -p 3306,3307,5432,6379,27017 <your-public-ip>
+
+# If 3307 or 6379 returns "open", you're vulnerable. Pull the latest
+# main, then re-run setup or manually patch:
+git pull
+docker compose down
+docker compose up -d
+```
+
+Rotate any passwords that may have leaked. The two values to rotate:
+
+```bash
+cd /opt/astradial   # or wherever you deployed
+
+# Generate strong replacements
+NEW_DB_ROOT=$(openssl rand -hex 24)
+NEW_DB_USER=$(openssl rand -hex 24)
+
+# Update .env
+sed -i "s|^DB_ROOT_PASSWORD=.*|DB_ROOT_PASSWORD=$NEW_DB_ROOT|" .env
+sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=$NEW_DB_USER|" .env
+
+# Apply inside MariaDB (volume already exists, env var alone won't update it)
+docker exec -i astradial-mariadb-1 mariadb -uroot -p<OLD_ROOT> <<SQL
+ALTER USER 'root'@'%'        IDENTIFIED BY '$NEW_DB_ROOT';
+ALTER USER 'root'@'localhost' IDENTIFIED BY '$NEW_DB_ROOT';
+ALTER USER 'astradial'@'%'   IDENTIFIED BY '$NEW_DB_USER';
+FLUSH PRIVILEGES;
+SQL
+
+# Restart api so it picks up the new DB_PASSWORD
+docker compose restart api
+```
+
+## Hardening checklist (recommended)
+
+Even with the defaults secured, run these on any production OSS host:
+
+1. **Confirm port exposure**: `ss -tlnp` — anything bound to `0.0.0.0`
+   that isn't 22, 80, 443, 5060/udp, 51820/udp, or your asterisk RTP
+   range should be `127.0.0.1`.
+2. **UFW + Docker**: even though port-bindings are now localhost-only,
+   set the `DOCKER-USER` chain to DROP-by-default and explicit-allow
+   only what's needed. See `internal-docs/docs/architecture/network-security.md`.
+3. **fail2ban**: install + enable jails for `sshd`, `asterisk-auth`
+   (SIP REGISTER brute-force), and `asterisk-scan` (SIP scanner
+   patterns).
+4. **DB backups off-box**: `mariadb-dump` daily, ship to S3 or any
+   remote storage. Ransomware can't drop what you've already mirrored.
+5. **MariaDB root password rotation**: even though it's no longer
+   exposed, the docker-init phase still uses
+   `MARIADB_ROOT_PASSWORD=$DB_ROOT_PASSWORD` from the env. Don't reuse
+   between deploys.
+6. **Don't expose admin UIs**: keep the editor (3001), netdata
+   (19999), pgAdmin etc. behind a VPN or Cloudflare Access.
+7. **TLS only**: serve the editor + api over HTTPS via Caddy (the
+   default with `--profile domain`).
+
+## Open issues we know about
+
+- The Asterisk AMI port (5038) is exposed inside the api container
+  but not to the host. Already safe.
+- Editor (3001) is exposed publicly when `--profile domain` is not
+  used. For internet-facing deployments, always use the domain
+  profile so Caddy handles TLS + you don't expose the raw editor.
+- WireGuard reseller plane (`wg-reseller`) is locked down via
+  `nft` rules — see `sip-gateway/reseller/lib/wg.sh`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,15 @@ services:
       MARIADB_USER: ${DB_USER:-astradial}
       MARIADB_PASSWORD: ${DB_PASSWORD:-changeme}
     ports:
-      - "${DB_EXTERNAL_PORT:-3307}:3306"
+      # Bind to 127.0.0.1 ONLY. Docker's iptables rules bypass UFW
+      # (https://docs.docker.com/network/iptables/), so anything mapped
+      # to 0.0.0.0 is reachable from the public internet even when ufw
+      # says it isn't. Internet-scanning ransomware groups regularly
+      # brute-force MariaDB/MySQL/PG/Redis on common ports — Skylink's
+      # OSS deployment was hit in 2026-05 when this was 0.0.0.0:3307.
+      # Other containers reach this via the docker network as `mariadb`
+      # regardless.
+      - "127.0.0.1:${DB_EXTERNAL_PORT:-3307}:3306"
     volumes:
       - mariadb_data:/var/lib/mysql
     healthcheck:
@@ -47,7 +55,10 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
     ports:
-      - "6379:6379"
+      # 127.0.0.1 only — same reasoning as mariadb. Redis without a
+      # password on a public IP is a known attacker target (RCE via
+      # CONFIG SET dir + write SSH keys).
+      - "127.0.0.1:6379:6379"
     networks:
       - astradial
 

--- a/setup.sh
+++ b/setup.sh
@@ -119,8 +119,13 @@ API_FQDN=${API_FQDN}
 
 DB_NAME=astradial
 DB_USER=astradial
-DB_PASSWORD=changeme
-DB_ROOT_PASSWORD=changeme
+# Strong random passwords for fresh installs. Skylink's first deploy
+# used the hardcoded "changeme" default and was compromised by an
+# automated MariaDB-ransomware scanner in 2026-05. Even though
+# docker-compose now binds MariaDB to 127.0.0.1 only, the password
+# should never be a dictionary word.
+DB_PASSWORD=$(openssl rand -hex 24 2>/dev/null || echo "changeme-please-replace-$(date +%s)")
+DB_ROOT_PASSWORD=$(openssl rand -hex 24 2>/dev/null || echo "changeme-please-replace-$(date +%s)")
 
 # Postgres (used only by workflow-engine; separate from the astrapbx mariadb)
 PG_DATABASE=workflow_db


### PR DESCRIPTION
## Summary

A Skylink-OSS deployment was compromised by an automated MariaDB ransomware scanner. Root cause: `docker-compose.yml` exposed MariaDB on `0.0.0.0:3307`, and `setup.sh` defaulted `DB_PASSWORD` and `DB_ROOT_PASSWORD` to `changeme`. Anyone using the OSS defaults is currently vulnerable.

## Changes

- **`docker-compose.yml`** — `mariadb` and `redis` published ports now bind to `127.0.0.1` only. Docker's iptables rules bypass UFW ([docs](https://docs.docker.com/network/iptables/)), so the old bindings were reachable from the public internet even with UFW active. Other containers reach these via the docker network so nothing breaks.
- **`setup.sh`** — `DB_PASSWORD` and `DB_ROOT_PASSWORD` now generated via `openssl rand -hex 24`. The `changeme` default is gone.
- **`SECURITY.md`** — added. Documents the issue, gives existing deployers a clear upgrade path (port scan + password rotation), and lists a hardening checklist for production hosts.

## Severity

**High.** Any OSS deployment cloned before this commit and running with default settings has a publicly reachable MariaDB on a guessable password. We have direct evidence of automated ransomware groups scanning for this — see the SECURITY.md "What changed" section.

## Test plan

- [x] `docker-compose config` validates ✓
- [x] `bash -n setup.sh` ✓
- [x] On Skylink VPS: applied changes, recreated mariadb container, verified `ss -tlnp | grep 3307` shows `127.0.0.1:3307` (not `0.0.0.0:3307`)
- [x] On Skylink VPS: api still connects to mariadb via docker network and bootstraps schema cleanly
- [ ] External port-scan from outside the VPS to confirm 3307 is no longer reachable

## Upgrade path for existing deployments

See `SECURITY.md` — pull, `docker compose down && up -d`, rotate the two DB passwords via the supplied SQL snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)