### PR TITLE
chore(security): README banner + .env.example placeholders + CI lint guardrail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,26 +15,33 @@ USE_FIREBASE=false
 NEXT_PUBLIC_USE_FIREBASE=false
 
 # ── Database ──
+# IMPORTANT: replace placeholders below with strong random values
+# (setup.sh does this automatically). NEVER ship to production with the
+# placeholder strings — they were the root cause of a real ransomware
+# incident in 2026-05. See SECURITY.md.
+#
+# Generate with: openssl rand -hex 24
 DB_NAME=astradial
 DB_USER=astradial
-DB_PASSWORD=changeme
-DB_ROOT_PASSWORD=changeme
+DB_PASSWORD=REPLACE_BEFORE_DEPLOY      # allow-weak-password-example
+DB_ROOT_PASSWORD=REPLACE_BEFORE_DEPLOY # allow-weak-password-example
 
 # ── Security ──
 # JWT_SECRET signs auth tokens; rotate it whenever you suspect compromise.
-JWT_SECRET=change-this-to-a-random-string
+# Generate with: openssl rand -hex 32
+JWT_SECRET=REPLACE_BEFORE_DEPLOY
 # INTERNAL_API_KEY authenticates pipecat-flow → astrapbx internal calls.
-# Generate fresh with: openssl rand -hex 24
-INTERNAL_API_KEY=change-this-to-a-random-string
+# Generate with: openssl rand -hex 24
+INTERNAL_API_KEY=REPLACE_BEFORE_DEPLOY
 
 # ── Admin account (created on first boot) ──
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=changeme
+ADMIN_PASSWORD=REPLACE_BEFORE_DEPLOY    # allow-weak-password-example
 ADMIN_NAME=Admin
 
 # ── Platform admin (for org management API) ──
 ADMIN_USERNAME=admin
-ADMIN_API_PASSWORD=admin
+ADMIN_API_PASSWORD=REPLACE_BEFORE_DEPLOY # allow-weak-password-example
 
 # ── Asterisk ──
 ASTERISK_AMI_SECRET=astradial

--- a/.github/workflows/security-lint.yml
+++ b/.github/workflows/security-lint.yml
@@ -1,0 +1,51 @@
+name: security-lint
+
+# Reject PRs that re-introduce known-bad defaults: dictionary passwords,
+# port-publish patterns that bypass UFW. See SECURITY.md for context.
+#
+# Triggered on every PR and every push to main.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    name: scan for dictionary passwords and public DB binds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: dictionary password literals
+        run: |
+          # Catches: DB_PASSWORD=changeme, password: admin, etc.
+          # Allowed: example/placeholder lines explicitly tagged with
+          # `# allow-weak-password-example`.
+          BAD_PATTERNS='(DB_PASSWORD|DB_ROOT_PASSWORD|ADMIN_PASSWORD|REDIS_PASSWORD|POSTGRES_PASSWORD|MARIADB_ROOT_PASSWORD|MARIADB_PASSWORD)\s*[:=]\s*[\x27\x22]?(changeme|password|admin|root|test|12345|123456|astradial|secret|qwerty|letmein)[\x27\x22]?'
+          if git grep -nE "$BAD_PATTERNS" -- ':!*.md' ':!SECURITY*' ':!*test*' ':!.github/workflows/security-lint.yml' | grep -v 'allow-weak-password-example'; then
+            echo ""
+            echo "::error::Found a dictionary password literal. Use \$(openssl rand -hex 24) or read from .env. See SECURITY.md."
+            exit 1
+          fi
+          echo "ok: no dictionary password literals"
+
+      - name: public docker port-publish without 127.0.0.1
+        run: |
+          # docker-compose 'ports' that don't bind to a specific IP get
+          # 0.0.0.0 by default, bypassing UFW. Catch any line like
+          # `- "<digits>:<digits>"` that ISN'T prefixed with an IP.
+          # Allowed values: 0.0.0.0 if explicit (forces author to think),
+          # or any non-DB port (we allow 80/443/22/SIP/RTP/etc on 0.0.0.0).
+          # This check is conservative: it flags any DB-shaped port binding
+          # (3306/3307/6379/5432/27017/3000-3099 etc.) that's not localhost.
+          if grep -rnE '^\s*-\s*"[0-9]+:[0-9]+"' docker-compose*.yml 2>/dev/null | grep -E '"(3306|3307|6379|5432|27017|9200|9300|11211):' ; then
+            echo ""
+            echo "::error::DB-like port mapped to 0.0.0.0 (default when no IP prefix). Bind to 127.0.0.1, e.g.: '127.0.0.1:3307:3306'. See SECURITY.md."
+            exit 1
+          fi
+          echo "ok: no public DB-port bindings"
+
+      - name: ensure SECURITY.md still exists
+        run: |
+          test -f SECURITY.md || (echo "::error::SECURITY.md was removed." && exit 1)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Astradial
 
+> ⚠️ **Security advisory (2026-05-28):** if you deployed before this
+> date, see [`SECURITY.md`](./SECURITY.md). Older `docker-compose.yml`
+> exposed MariaDB and Redis on `0.0.0.0` (Docker's iptables rules
+> bypass UFW), and `setup.sh` shipped `DB_PASSWORD=changeme` as a
+> default. Confirmed live exploitation of one deploy. Pull, redeploy,
+> rotate passwords. New defaults in `main` are safe.
+
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/astradial/astradial?style=social)](https://github.com/astradial/astradial/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/astradial/astradial)](https://github.com/astradial/astradial/issues)

--- a/setup.sh
+++ b/setup.sh
@@ -285,7 +285,7 @@ NEXT_PUBLIC_PBX_URL=${PBX_URL}
 SIP_HOST=${SIP_HOST}
 SIP_PORT=${SIP_PORT}
 ADMIN_EMAIL=admin@astradial.com
-ADMIN_PASSWORD=admin
+ADMIN_PASSWORD=not-used-in-cloud-mode  # allow-weak-password-example
 ADMIN_USERNAME=admin
 INTERNAL_API_KEY=not-needed-in-cloud-mode
 EOF


### PR DESCRIPTION
## Summary

Follow-up to #68 (the docker-compose public-DB-bind fix). Three layers to make sure the 2026-05-28 incident can't recur:

1. **README security banner** — `SECURITY.md` is loud and unmissable from the front page.
2. **`.env.example` placeholders** — replaced `changeme` literals with `REPLACE_BEFORE_DEPLOY` so nobody can accidentally ship the example to production.
3. **CI lint** — GitHub Actions workflow rejects PRs that re-introduce dictionary passwords or public DB port bindings.

Also fixes `setup.sh` cloud-mode template that emitted `ADMIN_PASSWORD=admin`.

## Lint rules (in `.github/workflows/security-lint.yml`)

- Any `(DB_PASSWORD|ADMIN_PASSWORD|...) = (changeme|password|admin|root|astradial|...)` literal → fail.
  Bypass intentional doc placeholders with `# allow-weak-password-example` on the same line.
- Any docker-compose `ports: - "<num>:<num>"` for a DB-shaped port (3306/3307/5432/6379/27017/...) without a `127.0.0.1` prefix → fail.
- `SECURITY.md` removed → fail.

## Test plan

- [x] Dry-run of lint against current `main`: no dictionary passwords, no public DB binds
- [x] Lint catches re-introduction (verified by reverting one placeholder + running locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)