### PR TITLE
feat(campaigns): lead-level pause/resume + studio editor layout/UX fixes

### DIFF
--- a/api/database/migrations/20260629120000-add-lead-run-paused.js
+++ b/api/database/migrations/20260629120000-add-lead-run-paused.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Lead-level pause/resume:
+//   1. Add 'paused' to campaign_lead_runs.status ENUM. A paused run is skipped
+//      by the scheduler (claims only 'pending'), advance() (acts only on
+//      pending/waiting/queued) and both workers — no engine changes needed.
+//   2. Add paused_at DATETIME NULL (informational / audit).
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const dialect = queryInterface.sequelize.getDialect();
+
+    if (dialect === 'mariadb' || dialect === 'mysql') {
+      // MODIFY COLUMN rewrites the full ENUM definition — list all values.
+      await queryInterface.sequelize.query(`
+        ALTER TABLE campaign_lead_runs
+        MODIFY COLUMN status ENUM('pending','queued','waiting','halted','completed','failed','paused')
+        NOT NULL DEFAULT 'pending'
+      `);
+    } else if (dialect === 'postgres') {
+      await queryInterface.sequelize.query(`
+        DO $$ BEGIN
+          ALTER TYPE enum_campaign_lead_runs_status ADD VALUE IF NOT EXISTS 'paused';
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+      `);
+    }
+
+    await queryInterface.addColumn('campaign_lead_runs', 'paused_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+      defaultValue: null,
+      comment: 'When the run was paused via lead-level pause; NULL when active',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('campaign_lead_runs', 'paused_at');
+
+    const dialect = queryInterface.sequelize.getDialect();
+    if (dialect === 'mariadb' || dialect === 'mysql') {
+      // Any paused rows must leave the enum before it's narrowed, or the
+      // MODIFY would truncate them. Treat a paused run as resumable → pending.
+      await queryInterface.sequelize.query(`
+        UPDATE campaign_lead_runs SET status = 'pending', next_run_at = NOW() WHERE status = 'paused'
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TABLE campaign_lead_runs
+        MODIFY COLUMN status ENUM('pending','queued','waiting','halted','completed','failed')
+        NOT NULL DEFAULT 'pending'
+      `);
+    }
+    // PostgreSQL: enum values can't be dropped without recreating the type.
+  },
+};

--- a/api/scripts/seed-hotel-campaign.js
+++ b/api/scripts/seed-hotel-campaign.js
@@ -1,0 +1,203 @@
+'use strict';
+
+/**
+ * Seeds ONE "Hotel Calls" campaign management demo for the first org:
+ *   • 1 CampaignBot   — "Hotel Booking Voice Bot" (resolves the call `script`)
+ *   • 1 CampaignTemplate (published) — 3 days, each day = [outbound call, WhatsApp]
+ *   • 1 Campaign (DRAFT)            — snapshot of the template
+ *   • 1 CampaignLead               — Hotel Guest, +91 99444 21125
+ *   • 1 CampaignLeadRun            — scheduler entry (day 0 / action 0, pending)
+ *
+ * WhatsApp template is a PLACEHOLDER (hotel_booking_confirmation /
+ * hotel_confirmations_v1) — the live MSG91 authkey is IP-restricted, so swap in
+ * the real approved template + namespace once this server's IP is whitelisted.
+ *
+ * Idempotent by name/phone — safe to re-run.
+ *
+ * Usage (inside the api container):  node scripts/seed-hotel-campaign.js
+ */
+
+const {
+  sequelize,
+  Organization,
+  CampaignBot,
+  CampaignTemplate,
+  Campaign,
+  CampaignLead,
+  CampaignLeadRun,
+} = require('../src/models');
+
+const BOT_NAME = 'Hotel Booking Voice Bot';
+const TEMPLATE_NAME = 'Hotel Calls — 3-Day Booking Confirmation';
+const CAMPAIGN_NAME = 'Hotel Calls – Booking Confirmation (Jun 2026)';
+const LEAD_PHONE = '+919944421125';
+
+// Real APPROVED MSG91 templates on integrated number 15558897024 (Grand Estancia
+// hotel brand). Namespace is shared across this account's templates.
+const WA_NAMESPACE = 'ab7728b6_9e3c_4160_b51e_958e57f151e0';
+const WA_LANG = 'en';
+
+function waAction(id, template) {
+  return {
+    id,
+    type: 'whatsapp',
+    template,
+    namespace: WA_NAMESPACE,
+    language: WA_LANG,
+    interest_keywords: ['confirm', 'yes', 'booking', 'thanks', 'check-in'],
+    options: {},
+  };
+}
+
+function callAction(id, intent) {
+  return {
+    id,
+    type: 'call',
+    script: BOT_NAME, // resolved to the CampaignBot by name
+    callerId: 'hotel-desk',
+    interest_keywords: ['confirm', 'book', 'yes', 'reschedule', 'cancel'],
+    options: { intent },
+  };
+}
+
+// 3 days, each day fires an outbound CALL then a WhatsApp. gap = days to wait.
+const WORKFLOW = {
+  meta: { vertical: 'hospitality', goal: 'booking_confirmation', name: TEMPLATE_NAME },
+  days: [
+    {
+      id: 'day-1',
+      gap: 0,
+      actions: [
+        callAction('d1-call', 'welcome_confirm_booking'),
+        waAction('d1-wa', 'ge_welcome'),
+      ],
+    },
+    {
+      id: 'day-2',
+      gap: 1,
+      actions: [
+        callAction('d2-call', 'reminder_pre_arrival'),
+        waAction('d2-wa', 'grand_estancia_uti'),
+      ],
+    },
+    {
+      id: 'day-3',
+      gap: 1,
+      actions: [
+        callAction('d3-call', 'final_confirmation'),
+        waAction('d3-wa', 'grand_estancia'),
+      ],
+    },
+  ],
+};
+
+async function main() {
+  await sequelize.authenticate();
+  console.log('[hotel-seed] DB connection OK');
+
+  const org = await Organization.findOne({ order: [['created_at', 'ASC']] });
+  if (!org) {
+    console.error('[hotel-seed] No organization found — create one first.');
+    process.exit(1);
+  }
+  console.log(`[hotel-seed] org "${org.name}" (${org.id})`);
+
+  // 1) Voice bot (referenced by call actions' `script`)
+  let [bot] = await CampaignBot.findOrCreate({
+    where: { org_id: org.id, name: BOT_NAME },
+    defaults: {
+      org_id: org.id,
+      name: BOT_NAME,
+      language: 'en',
+      keywords: ['confirm', 'book', 'reschedule', 'cancel', 'check-in'],
+      max_words: 3,
+      call_timeout: 8,
+    },
+  });
+  console.log(`[hotel-seed] bot ${bot.name} (${bot.id})`);
+
+  // 2) Published template
+  let template = await CampaignTemplate.findOne({ where: { org_id: org.id, name: TEMPLATE_NAME } });
+  if (!template) {
+    template = await CampaignTemplate.create({
+      org_id: org.id,
+      name: TEMPLATE_NAME,
+      description: '3-day hotel booking-confirmation cadence: an outbound AI call + a WhatsApp every day.',
+      status: 'published',
+      version: 1,
+      workflow: WORKFLOW,
+    });
+    console.log(`[hotel-seed] + template ${template.name} (${template.id})`);
+  } else {
+    await template.update({ workflow: WORKFLOW, status: 'published' });
+    console.log(`[hotel-seed] = template exists, refreshed workflow (${template.id})`);
+  }
+
+  // 3) Campaign (DRAFT) with frozen snapshot
+  const startAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  let campaign = await Campaign.findOne({ where: { org_id: org.id, name: CAMPAIGN_NAME } });
+  if (!campaign) {
+    campaign = await Campaign.create({
+      org_id: org.id,
+      name: CAMPAIGN_NAME,
+      description: 'Demo: 3-day hotel calls + WhatsApp flow for a single lead.',
+      template_id: template.id,
+      template_snapshot: WORKFLOW,
+      status: 'draft',
+      start_at: startAt,
+      stats: { total: 0, contacted: 0, engaged: 0, interested: 0, qualified: 0 },
+    });
+    console.log(`[hotel-seed] + campaign ${campaign.name} (${campaign.id}) [draft]`);
+  } else {
+    await campaign.update({ template_id: template.id, template_snapshot: WORKFLOW, start_at: startAt });
+    console.log(`[hotel-seed] = campaign exists, refreshed snapshot (${campaign.id})`);
+  }
+
+  // 4) Lead
+  let [lead] = await CampaignLead.findOrCreate({
+    where: { org_id: org.id, campaign_id: campaign.id, phone: LEAD_PHONE },
+    defaults: {
+      org_id: org.id,
+      campaign_id: campaign.id,
+      name: 'Hotel Guest',
+      phone: LEAD_PHONE,
+      country: 'IN',
+      business: 'Grand Hotel',
+      source: 'manual',
+      status: 'raw',
+      custom_fields: { room_type: 'Deluxe', check_in: '2026-07-01', notes: 'Seed lead for Hotel Calls demo' },
+      enrolled_at: new Date(),
+    },
+  });
+  console.log(`[hotel-seed] lead ${lead.name} ${lead.phone} (${lead.id})`);
+
+  // 5) Scheduler run (day 0 / action 0, pending) — campaign is draft so it won't fire until launch
+  let [run] = await CampaignLeadRun.findOrCreate({
+    where: { org_id: org.id, campaign_id: campaign.id, campaign_lead_id: lead.id },
+    defaults: {
+      org_id: org.id,
+      campaign_id: campaign.id,
+      campaign_lead_id: lead.id,
+      current_day_index: 0,
+      current_action_index: 0,
+      next_run_at: startAt,
+      status: 'pending',
+    },
+  });
+  console.log(`[hotel-seed] run ${run.id} (status=${run.status})`);
+
+  // 6) Refresh stats.total
+  const total = await CampaignLead.count({ where: { campaign_id: campaign.id } });
+  await campaign.update({ stats: { ...campaign.stats, total } });
+
+  console.log(`\n[hotel-seed] DONE.`);
+  console.log(`  campaign_id = ${campaign.id}`);
+  console.log(`  org_id      = ${org.id}`);
+  console.log(`  status      = draft  (leads=${total})  days=${WORKFLOW.days.length} (call+whatsapp each)`);
+  await sequelize.close();
+}
+
+main().catch((err) => {
+  console.error('[hotel-seed] FAILED:', err);
+  process.exit(1);
+});

--- a/api/scripts/seed-whatsapp-blast.js
+++ b/api/scripts/seed-whatsapp-blast.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Seeds ONE WhatsApp-only campaign for manual launch testing:
+ *   • 1 published CampaignTemplate — single day, single WhatsApp action using
+ *     the real APPROVED, no-variable hotel template `grand_estancia_uti`
+ *     (no variables = no risk of a variable-mismatch send error).
+ *   • 1 Campaign (DRAFT) — pinned to integrated number 15558897024.
+ *   • 20 CampaignLeads, ALL with the same number 919944421125 (digits only,
+ *     the format MSG91 expects), each with a CampaignLeadRun (pending).
+ *
+ * No call actions. Left as DRAFT — the operator launches it manually, which
+ * fires 20 WhatsApp sends to that number (org WA rate limit default 60/min).
+ *
+ * Usage (inside the api container):  node scripts/seed-whatsapp-blast.js
+ */
+
+const {
+  sequelize,
+  Organization,
+  CampaignTemplate,
+  Campaign,
+  CampaignLead,
+  CampaignLeadRun,
+} = require('../src/models');
+
+const TEMPLATE_NAME = 'WhatsApp Test – Grand Estancia (no-var)';
+const CAMPAIGN_NAME = 'WhatsApp Blast Test – 20 leads (Jun 2026)';
+const LEAD_PHONE = '919944421125'; // digits only — MSG91 `to` format
+const LEAD_COUNT = 20;
+const INTEGRATED_NUMBER = '15558897024';
+
+const WA_TEMPLATE = 'grand_estancia_uti';
+const WA_NAMESPACE = 'ab7728b6_9e3c_4160_b51e_958e57f151e0';
+
+const WORKFLOW = {
+  meta: { vertical: 'hospitality', goal: 'whatsapp_test', name: TEMPLATE_NAME },
+  days: [
+    {
+      id: 'day-1',
+      gap: 0,
+      actions: [
+        {
+          id: 'd1-wa',
+          type: 'whatsapp',
+          template: WA_TEMPLATE,
+          namespace: WA_NAMESPACE,
+          language: 'en',
+          interest_keywords: ['yes', 'interested', 'book', 'confirm'],
+          options: {},
+        },
+      ],
+    },
+  ],
+};
+
+async function main() {
+  await sequelize.authenticate();
+  console.log('[wa-seed] DB connection OK');
+
+  const org = await Organization.findOne({ order: [['created_at', 'ASC']] });
+  if (!org) { console.error('[wa-seed] No organization found.'); process.exit(1); }
+  console.log(`[wa-seed] org "${org.name}" (${org.id})`);
+
+  // 1) Published template (whatsapp-only)
+  let template = await CampaignTemplate.findOne({ where: { org_id: org.id, name: TEMPLATE_NAME } });
+  if (!template) {
+    template = await CampaignTemplate.create({
+      org_id: org.id, name: TEMPLATE_NAME,
+      description: 'WhatsApp-only test flow: single send of grand_estancia_uti (no variables).',
+      status: 'published', version: 1, workflow: WORKFLOW,
+    });
+    console.log(`[wa-seed] + template ${template.name} (${template.id}) [published]`);
+  } else {
+    await template.update({ workflow: WORKFLOW, status: 'published' });
+    console.log(`[wa-seed] = template refreshed (${template.id})`);
+  }
+
+  // 2) Campaign (DRAFT) — operator launches manually
+  const startAt = new Date();
+  let campaign = await Campaign.findOne({ where: { org_id: org.id, name: CAMPAIGN_NAME } });
+  if (!campaign) {
+    campaign = await Campaign.create({
+      org_id: org.id, name: CAMPAIGN_NAME,
+      description: 'WhatsApp-only blast test: 20 leads, same number. Launch manually.',
+      template_id: template.id, template_snapshot: WORKFLOW,
+      status: 'draft', start_at: startAt,
+      options: { msg91_integrated_number: INTEGRATED_NUMBER },
+      stats: { total: 0, contacted: 0, engaged: 0, interested: 0, qualified: 0 },
+    });
+    console.log(`[wa-seed] + campaign ${campaign.name} (${campaign.id}) [draft]`);
+  } else {
+    await campaign.update({
+      template_id: template.id, template_snapshot: WORKFLOW, start_at: startAt,
+      options: { msg91_integrated_number: INTEGRATED_NUMBER },
+    });
+    console.log(`[wa-seed] = campaign refreshed (${campaign.id})`);
+  }
+
+  // 3) 20 leads (same number) — idempotent: top up to LEAD_COUNT
+  const existing = await CampaignLead.count({ where: { campaign_id: campaign.id } });
+  const toCreate = Math.max(0, LEAD_COUNT - existing);
+  const leadRows = [];
+  for (let i = existing; i < existing + toCreate; i++) {
+    leadRows.push({
+      org_id: org.id, campaign_id: campaign.id,
+      name: `Test Lead ${i + 1}`, phone: LEAD_PHONE, country: 'IN',
+      business: 'Grand Estancia', source: 'manual', status: 'raw',
+      custom_fields: { batch: 'wa-blast', idx: i + 1 }, enrolled_at: new Date(),
+    });
+  }
+  const createdLeads = leadRows.length ? await CampaignLead.bulkCreate(leadRows, { returning: true }) : [];
+  console.log(`[wa-seed] leads: ${existing} existing + ${createdLeads.length} created`);
+
+  // 4) One pending run per new lead
+  const runRows = createdLeads.map((l) => ({
+    org_id: org.id, campaign_id: campaign.id, campaign_lead_id: l.id,
+    current_day_index: 0, current_action_index: 0,
+    next_run_at: startAt, status: 'pending',
+  }));
+  if (runRows.length) await CampaignLeadRun.bulkCreate(runRows);
+  console.log(`[wa-seed] + ${runRows.length} runs (pending)`);
+
+  // 5) stats.total
+  const total = await CampaignLead.count({ where: { campaign_id: campaign.id } });
+  await campaign.update({ stats: { ...campaign.stats, total } });
+
+  console.log(`\n[wa-seed] DONE.`);
+  console.log(`  campaign_id = ${campaign.id}  status=draft  leads=${total}`);
+  console.log(`  template    = ${WA_TEMPLATE} (no variables)  sender=${INTEGRATED_NUMBER}`);
+  console.log(`  → Launch manually in the UI; ${total} WhatsApp sends will fire to ${LEAD_PHONE}.`);
+  await sequelize.close();
+}
+
+main().catch((err) => { console.error('[wa-seed] FAILED:', err); process.exit(1); });

--- a/api/src/models/CampaignLeadRun.js
+++ b/api/src/models/CampaignLeadRun.js
@@ -10,11 +10,12 @@ module.exports = (sequelize) => {
     current_action_index: { type: DataTypes.INTEGER, defaultValue: 0 },
     next_run_at: { type: DataTypes.DATE, allowNull: false },
     status: {
-      type: DataTypes.ENUM('pending', 'queued', 'waiting', 'halted', 'completed', 'failed'),
+      type: DataTypes.ENUM('pending', 'queued', 'waiting', 'halted', 'completed', 'failed', 'paused'),
       defaultValue: 'pending',
     },
     asterisk_channel_id: { type: DataTypes.STRING(64), allowNull: true },
     halted_at: { type: DataTypes.DATE, allowNull: true },
+    paused_at: { type: DataTypes.DATE, allowNull: true },
     locked_at: { type: DataTypes.DATE, allowNull: true },
     locked_by: { type: DataTypes.STRING(64), allowNull: true },
     attempts: { type: DataTypes.TINYINT, defaultValue: 0 },

--- a/api/src/routes/campaigns.js
+++ b/api/src/routes/campaigns.js
@@ -16,6 +16,7 @@ const {
   CampaignTemplate,
   Campaign,
   CampaignLead,
+  CampaignLeadRun,
   CampaignLeadField,
   CampaignEvent,
   CampaignApproval,
@@ -30,7 +31,7 @@ const {
   throughputUpdate,
 } = require('../middleware/campaign-validators');
 const { importCsv } = require('../services/campaign-csv-importer');
-const { getQueue, IMPORT_QUEUE } = require('../jobs/campaignQueues');
+const { getQueue, IMPORT_QUEUE, WHATSAPP_QUEUE, CALLS_QUEUE } = require('../jobs/campaignQueues');
 
 // Separate multer for the async path — 250 MB cap to handle 5-lakh-row
 // uploads. Sync importer keeps its 5 MB cap below; the dialog routes
@@ -1018,14 +1019,95 @@ router.get('/:id/leads', requirePermission('campaigns.read'), async (req, res) =
   } catch (e) { res.status(500).json({ error: e.message }); }
 });
 
+// ── Lead-level pause/resume helpers ─────────────────────────────────
+// A run is "active" (pausable) only in these states. paused → resumable.
+const PAUSABLE_RUN_STATUSES = ['pending', 'queued', 'waiting'];
+
+// Fetch a lead with its run status flattened onto the payload, so the UI
+// can choose Pause vs Resume vs disabled.
+async function serializeLeadWithRun(campaignId, leadId, orgId) {
+  const row = await CampaignLead.findOne({
+    where: { id: leadId, campaign_id: campaignId, org_id: orgId },
+    include: [{
+      model: CampaignLeadRun,
+      as: 'run',
+      attributes: ['status', 'paused_at', 'current_day_index', 'current_action_index', 'next_run_at'],
+    }],
+  });
+  if (!row) return null;
+  const json = row.toJSON();
+  json.run_status = json.run ? json.run.status : null;
+  json.run_paused_at = json.run ? json.run.paused_at : null;
+  return json;
+}
+
+// Resolve the lead's run deterministically (latest, in case of re-enrollment).
+async function findLeadRun(campaignId, leadId, orgId) {
+  const lead = await CampaignLead.findOne({
+    where: { id: leadId, campaign_id: campaignId, org_id: orgId },
+    attributes: ['id'],
+  });
+  if (!lead) return { httpError: 404, message: 'Lead not found' };
+  const run = await CampaignLeadRun.findOne({
+    where: { campaign_lead_id: lead.id, campaign_id: campaignId, org_id: orgId },
+    order: [['created_at', 'DESC']],
+  });
+  if (!run) return { httpError: 404, message: 'No campaign run for this lead' };
+  return { run };
+}
+
+// Remove the BullMQ job for a run's current action from both channel queues.
+// Stable jobIds (`run-<id>-d<day>-a<action>`) are deduped by BullMQ and kept
+// 24h after completion, so without this a pause→resume of a queued WhatsApp
+// action would never re-fire. Best-effort (an active job can't be removed).
+async function removeRunChannelJobs(run) {
+  const jobId = `run-${run.id}-d${run.current_day_index}-a${run.current_action_index}`;
+  for (const qname of [WHATSAPP_QUEUE, CALLS_QUEUE]) {
+    try {
+      const job = await getQueue(qname).getJob(jobId);
+      if (job) await job.remove();
+    } catch (_) { /* best-effort: active/locked jobs can't be removed */ }
+  }
+}
+
 router.get('/:id/leads/:leadId', requirePermission('campaigns.read'), async (req, res) => {
   try {
-    const row = await CampaignLead.findOne({
-      where: { id: req.params.leadId, campaign_id: req.params.id, org_id: req.orgId },
-    });
-    if (!row) return res.status(404).json({ error: 'Lead not found' });
-    res.json(row);
+    const json = await serializeLeadWithRun(req.params.id, req.params.leadId, req.orgId);
+    if (!json) return res.status(404).json({ error: 'Lead not found' });
+    res.json(json);
   } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Pause a single lead's automation run (without pausing the whole campaign).
+router.post('/:id/leads/:leadId/pause', requirePermission('campaigns.write'), async (req, res) => {
+  try {
+    const r = await findLeadRun(req.params.id, req.params.leadId, req.orgId);
+    if (r.httpError) return res.status(r.httpError).json({ error: r.message });
+    const { run } = r;
+    if (!PAUSABLE_RUN_STATUSES.includes(run.status)) {
+      return res.status(409).json({ error: `Cannot pause a run in status "${run.status}"` });
+    }
+    await removeRunChannelJobs(run); // drop the pending job so it can't fire while paused
+    await run.update({ status: 'paused', paused_at: new Date(), locked_at: null, locked_by: null });
+    res.json(await serializeLeadWithRun(req.params.id, req.params.leadId, req.orgId));
+  } catch (e) { res.status(400).json({ error: e.message }); }
+});
+
+// Resume a paused lead run — re-enters the scheduler at the saved day/action.
+router.post('/:id/leads/:leadId/resume', requirePermission('campaigns.write'), async (req, res) => {
+  try {
+    const r = await findLeadRun(req.params.id, req.params.leadId, req.orgId);
+    if (r.httpError) return res.status(r.httpError).json({ error: r.message });
+    const { run } = r;
+    if (run.status !== 'paused') {
+      return res.status(409).json({ error: `Cannot resume a run in status "${run.status}"` });
+    }
+    await removeRunChannelJobs(run); // clear any stale completed job so re-enqueue isn't deduped
+    await run.update({
+      status: 'pending', paused_at: null, next_run_at: new Date(), locked_at: null, locked_by: null,
+    });
+    res.json(await serializeLeadWithRun(req.params.id, req.params.leadId, req.orgId));
+  } catch (e) { res.status(400).json({ error: e.message }); }
 });
 
 router.patch('/:id/leads/:leadId', requirePermission('campaigns.write'), async (req, res) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,8 +106,8 @@ services:
     build: ./api
     restart: unless-stopped
     ports:
-      - "9000:3000"
-      - "127.0.0.1:8765:8765"
+      - "9001:3000"
+      - "127.0.0.1:8766:8765"
     environment:
       - HOST=0.0.0.0
       - PORT=3000
@@ -185,7 +185,7 @@ services:
         NEXT_PUBLIC_USE_FIREBASE: ${NEXT_PUBLIC_USE_FIREBASE:-false}
     restart: unless-stopped
     ports:
-      - "3001:3001"
+      - "3011:3001"
     environment:
       - NEXT_PUBLIC_ASTRADIAL_MODE=${ASTRADIAL_MODE:-selfhosted}
       - NEXT_PUBLIC_USE_FIREBASE=${NEXT_PUBLIC_USE_FIREBASE:-false}
@@ -215,7 +215,7 @@ services:
     build: ./workflow-engine
     restart: unless-stopped
     ports:
-      - "127.0.0.1:3002:3002"
+      - "127.0.0.1:3012:3002"
     environment:
       - REDIS_URL=redis://redis:6379
       - API_URL=http://api:8000
@@ -241,7 +241,7 @@ services:
     build: ./pipecat-flow
     restart: unless-stopped
     ports:
-      - "127.0.0.1:7860:7860"
+      - "127.0.0.1:7871:7860"
     environment:
       - GATEWAY_HOST=0.0.0.0
       - GATEWAY_PORT=7860

--- a/editor/app/dashboard/[orgId]/campaigns/[campaignId]/page.tsx
+++ b/editor/app/dashboard/[orgId]/campaigns/[campaignId]/page.tsx
@@ -9,7 +9,7 @@
 // 60-second polling on /campaigns/:id/dashboard.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, Pause, Play, RotateCw, Upload, WifiOff } from "lucide-react";
+import { ChevronLeft, Pause, Play, RotateCw, WifiOff } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { lazy, Suspense, useDeferredValue, useEffect, useState, useTransition } from "react";
 
@@ -136,13 +136,6 @@ export default function CampaignDetailPage() {
           </p>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <button
-            type="button"
-            className="cmp-btn cmp-btn-outline cmp-btn-sm"
-            onClick={() => router.push(`/dashboard/${orgId}/campaigns/${campaignId}/imports`)}
-          >
-            <Upload size={14} /> Imports
-          </button>
           {(isDraft || isScheduled) && (
             <button
               type="button"

--- a/editor/app/dashboard/[orgId]/campaigns/studio/[templateId]/page.tsx
+++ b/editor/app/dashboard/[orgId]/campaigns/studio/[templateId]/page.tsx
@@ -539,8 +539,9 @@ export default function StudioEditorPage() {
         />
       </div>
 
-      {/* Save-pending indicator */}
-      {dirty && (
+      {/* Save-pending indicator — hidden while the inspector panel is open
+          (the inspector has its own save/done footer). */}
+      {dirty && !selection && (
         <div
           style={{
             position: "fixed",
@@ -1356,6 +1357,18 @@ function Inspector({
   if (!day || !action) return null;
   const def = ACTION_TYPES[action.type];
 
+  // Resolve the saved phone-bot value against the fetched bots. The stored
+  // `script` is normally a bot id (UUID), but legacy/seeded data may hold the
+  // bot *name* — match on either so the dropdown shows the saved bot instead
+  // of rendering blank. `selectedBot` is undefined when nothing is saved or the
+  // saved bot is unknown (deleted, or the list failed to fetch).
+  const savedScript = action.type === "call" ? action.script || "" : "";
+  const selectedBot =
+    voiceBots.find((b) => b.id === savedScript) ||
+    voiceBots.find((b) => b.name === savedScript);
+  const botSelectValue = selectedBot ? selectedBot.id : savedScript || "__none";
+  const savedBotUnknown = Boolean(savedScript) && !selectedBot;
+
   return (
     <aside className="cmp-editor-inspector">
       <div className="cmp-inspector-head-row">
@@ -1595,11 +1608,11 @@ function Inspector({
           <div className="cmp-field">
             <label className="cmp-field-label">Phone bot</label>
             <Select
-              value={action.script || "__none"}
+              value={botSelectValue}
               onValueChange={(value) => {
                 updateAction(day.id, action.id, { script: value === "__none" ? "" : value });
               }}
-              disabled={voiceBotsLoading || voiceBots.length === 0}
+              disabled={voiceBotsLoading || (voiceBots.length === 0 && !savedScript)}
             >
               <SelectTrigger className="h-9 w-full text-[13.5px]">
                 <SelectValue placeholder="Select a bot…" />
@@ -1613,6 +1626,9 @@ function Inspector({
                       {bot.name}
                     </SelectItem>
                   ))}
+                  {savedBotUnknown && (
+                    <SelectItem value={savedScript}>{savedScript} (saved)</SelectItem>
+                  )}
                 </SelectGroup>
               </SelectContent>
             </Select>
@@ -1621,11 +1637,13 @@ function Inspector({
                 ? "Loading bots…"
                 : voiceBotsError
                   ? voiceBotsError
-                  : voiceBots.length === 0
+                  : voiceBots.length === 0 && !savedScript
                     ? "Create Astralite bots in the Bots section."
-                    : action.script
-                      ? `Saved bot id: ${action.script}`
-                      : "Campaign Bot ID is saved with the workflow."}
+                    : selectedBot
+                      ? `Saved bot: ${selectedBot.name}`
+                      : savedScript
+                        ? `Saved bot "${savedScript}" was not found — pick one above.`
+                        : "Campaign Bot ID is saved with the workflow."}
             </div>
           </div>
           <div className="cmp-field">

--- a/editor/app/dashboard/[orgId]/layout.tsx
+++ b/editor/app/dashboard/[orgId]/layout.tsx
@@ -97,7 +97,7 @@ export default function OrgLayout({ children }: { children: React.ReactNode }) {
       <AppSidebar orgId={orgId} orgName={orgName} variant="inset" />
       <SidebarInset>
         <SiteHeader />
-        <div className="flex flex-1 flex-col">{children}</div>
+        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </SidebarInset>
     </SidebarProvider>
   );

--- a/editor/components/campaigns/FunnelView.tsx
+++ b/editor/components/campaigns/FunnelView.tsx
@@ -48,7 +48,7 @@ const FunnelStep = memo(function FunnelStep({ label, value, sub, pctValue, showP
 export function FunnelView({ data }: { data: FunnelData }) {
   const total = data.total || 1;
   const steps: StepProps[] = [
-    { label: "Total", value: data.total, sub: "in campaign", pctValue: 100, showPct: false },
+    { label: "Total", value: data.total, sub: "in campaign", pctValue: data.total > 0 ? 100 : 0, showPct: false },
     {
       label: "Contacted",
       value: data.contacted,

--- a/editor/components/campaigns/LeadDrawer.tsx
+++ b/editor/components/campaigns/LeadDrawer.tsx
@@ -4,7 +4,7 @@
 // PATCH /campaigns/:id/leads/:leadId with optimistic rollback (§11.23.4).
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, Clock, Pause, X } from "lucide-react";
+import { AlertCircle, Clock, Pause, Play, X } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -96,6 +96,44 @@ export function LeadDrawer({ open, campaignId, leadId, onClose }: Props) {
     },
   });
 
+  // Lead-level pause/resume. Optimistically flips run_status; the leads-list
+  // invalidation prefix-matches this single-lead query so it re-syncs.
+  function makeRunMut(
+    fn: () => Promise<CampaignLead>,
+    optimistic: CampaignLead["run_status"],
+    failMsg: string
+  ) {
+    return {
+      mutationFn: fn,
+      onMutate: async () => {
+        await qc.cancelQueries({ queryKey: ["campaigns", campaignId, "leads", leadId] });
+        const prev = qc.getQueryData<CampaignLead>(["campaigns", campaignId, "leads", leadId]);
+        if (prev) {
+          qc.setQueryData<CampaignLead>(["campaigns", campaignId, "leads", leadId], {
+            ...prev,
+            run_status: optimistic,
+          });
+        }
+        return { prev };
+      },
+      onError: (_e: unknown, _v: void, ctx: { prev?: CampaignLead } | undefined) => {
+        if (ctx?.prev) qc.setQueryData(["campaigns", campaignId, "leads", leadId], ctx.prev);
+        showToast(failMsg, "error");
+      },
+      onSettled: () => {
+        qc.invalidateQueries({ queryKey: ["campaigns", campaignId, "kanban"] });
+        qc.invalidateQueries({ queryKey: ["campaigns", campaignId, "leads"] });
+        qc.invalidateQueries({ queryKey: ["campaigns", campaignId, "dashboard"] });
+      },
+    };
+  }
+  const pauseMut = useMutation(
+    makeRunMut(() => leadsApi.pause(campaignId, leadId as string), "paused", "Pause failed")
+  );
+  const resumeMut = useMutation(
+    makeRunMut(() => leadsApi.resume(campaignId, leadId as string), "pending", "Resume failed")
+  );
+
   if (!open || typeof window === "undefined") return null;
 
   const lead = leadQ.data;
@@ -152,7 +190,7 @@ export function LeadDrawer({ open, campaignId, leadId, onClose }: Props) {
                   <SelectTrigger className="h-9 w-full text-[13.5px]">
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent className="z-[70]">
                     <SelectGroup>
                       <SelectLabel>Status</SelectLabel>
                       {STATUS_OPTIONS.map((opt) => (
@@ -219,18 +257,60 @@ export function LeadDrawer({ open, campaignId, leadId, onClose }: Props) {
             )}
           </div>
 
-          {lead && (
-            <div style={{ display: "flex", gap: 8 }}>
-              <button
-                className="cmp-btn cmp-btn-outline cmp-btn-sm"
-                style={{ flex: 1 }}
-                disabled
-                title="Lead-level pause is not available yet"
-              >
-                <Pause size={14} /> Pause unavailable
-              </button>
-            </div>
-          )}
+          {lead && (() => {
+            const rs = lead.run_status;
+            const busy = pauseMut.isPending || resumeMut.isPending;
+            if (rs === "paused") {
+              return (
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    className="cmp-btn cmp-btn-outline cmp-btn-sm"
+                    style={{ flex: 1 }}
+                    disabled={busy}
+                    onClick={() => resumeMut.mutate()}
+                  >
+                    <Play size={14} /> {busy ? "Resuming…" : "Resume lead"}
+                  </button>
+                </div>
+              );
+            }
+            if (rs === "pending" || rs === "queued" || rs === "waiting") {
+              return (
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    className="cmp-btn cmp-btn-outline cmp-btn-sm"
+                    style={{ flex: 1 }}
+                    disabled={busy}
+                    onClick={() => pauseMut.mutate()}
+                  >
+                    <Pause size={14} /> {busy ? "Pausing…" : "Pause lead"}
+                  </button>
+                </div>
+              );
+            }
+            const reason =
+              rs == null
+                ? "No active run"
+                : rs === "halted"
+                  ? "Lead halted"
+                  : rs === "completed"
+                    ? "Run completed"
+                    : rs === "failed"
+                      ? "Run failed"
+                      : "Pause unavailable";
+            return (
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  className="cmp-btn cmp-btn-outline cmp-btn-sm"
+                  style={{ flex: 1 }}
+                  disabled
+                  title={reason}
+                >
+                  <Pause size={14} /> {reason}
+                </button>
+              </div>
+            );
+          })()}
         </div>
       </div>
 

--- a/editor/components/ui/sidebar.tsx
+++ b/editor/components/ui/sidebar.tsx
@@ -319,7 +319,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main
       <main
         ref={ref}
         className={cn(
-          "flex w-full flex-1 flex-col bg-background",
+          "flex w-full min-w-0 flex-1 flex-col bg-background",
           "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-60 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
           className
         )}

--- a/editor/lib/campaigns/client.ts
+++ b/editor/lib/campaigns/client.ts
@@ -311,6 +311,11 @@ export const leads = {
     req<TranscriptPayload>(`/${campaignId}/leads/${leadId}/transcript/${eventId}`, {
       signal: opts.signal,
     }),
+  // Lead-level pause/resume — pauses just this lead's run, not the campaign.
+  pause: (campaignId: string, leadId: string) =>
+    req<CampaignLead>(`/${campaignId}/leads/${leadId}/pause`, { method: "POST" }),
+  resume: (campaignId: string, leadId: string) =>
+    req<CampaignLead>(`/${campaignId}/leads/${leadId}/resume`, { method: "POST" }),
 };
 
 // ── PR 4: per-campaign dashboard summary ──

--- a/editor/lib/campaigns/types.ts
+++ b/editor/lib/campaigns/types.ts
@@ -153,9 +153,22 @@ export interface CampaignLead {
   current_node_id: string | null;
   crm_contact_id: string | null;
   enrolled_at: string | null;
+  // Run-level execution state, flattened from the lead's CampaignLeadRun.
+  // Drives the drawer's Pause/Resume button. Null when the lead has no run.
+  run_status?: LeadRunStatus | null;
+  run_paused_at?: string | null;
   createdAt: string;
   updatedAt: string;
 }
+
+export type LeadRunStatus =
+  | "pending"
+  | "queued"
+  | "waiting"
+  | "halted"
+  | "completed"
+  | "failed"
+  | "paused";
 
 export type EventKind =
   | "enrolled"

--- a/editor/styles/campaigns.css
+++ b/editor/styles/campaigns.css
@@ -178,7 +178,16 @@
 }
 
 /* ── Page header (heading + subheading + actions) ────────────────── */
-.cmp-page-pad { padding: 28px 32px; max-width: 1500px; }
+.cmp-page-pad { padding: 28px 32px; max-width: 1500px; min-width: 0; }
+/* Containment: the dashboard layout wraps page content in a flex column
+   (`<div className="flex flex-1 flex-col">` in [orgId]/layout.tsx, inside
+   SidebarInset's `flex w-full flex-1 flex-col`). Flex items default to
+   min-width:auto and refuse to shrink below their content's intrinsic
+   width, so the kanban board's min-content (6 × 260px) would stretch the
+   whole page and force horizontal scroll. min-width:0 on the flex item
+   that holds .cmp-page-pad lets it shrink so .cmp-kanban-wrap can scroll
+   internally instead. The List view is unaffected (its table shrinks). */
+.flex.flex-1.flex-col:has(> .cmp-page-pad) { min-width: 0; }
 .cmp-page-actions-row {
   display: flex;
   align-items: flex-end;
@@ -493,7 +502,13 @@ textarea.cmp-input { height: auto; padding: 10px 12px; resize: vertical; }
  * section. All names prefixed cmp-.
  * ──────────────────────────────────────────────────────────────── */
 
-.cmp-studio-shell { display: flex; flex-direction: column; height: 100vh; min-height: 0; overflow: hidden; background: var(--background); }
+/* Definite height = viewport minus the SiteHeader (--header-height, 48px) and
+   the inset <main>'s m-2 margins (0.5rem top + 0.5rem bottom = 1rem). The
+   parent flex chain (SidebarProvider) is only `min-h-svh` — a floor, not a
+   cap — so `height:100%` would resolve to auto and the whole page would grow.
+   A definite height here is what lets the inner canvas (and palette/inspector)
+   scroll internally instead of scrolling the window. */
+.cmp-studio-shell { display: flex; flex-direction: column; height: calc(100dvh - var(--header-height, 3rem) - 1rem); min-height: 0; overflow: hidden; background: var(--background); }
 .cmp-editor-body  { display: flex; flex: 1; min-height: 0; overflow: hidden; }
 
 /* Top toolbar */
@@ -532,6 +547,7 @@ textarea.cmp-input { height: auto; padding: 10px 12px; resize: vertical; }
   background: var(--card);
   display: flex; flex-direction: column; gap: 16px;
   padding: 18px 14px;
+  min-height: 0; overflow-y: auto;
 }
 .cmp-palette-head  { display: flex; flex-direction: column; gap: 2px; padding: 0 4px; }
 .cmp-palette-title { font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
@@ -581,6 +597,11 @@ textarea.cmp-input { height: auto; padding: 10px 12px; resize: vertical; }
     oklch(0.985 0 0);
   padding: 32px 48px 80px;
   display: flex; justify-content: center;
+}
+.dark .cmp-canvas-wrap {
+  background:
+    radial-gradient(circle, oklch(0.30 0.006 285.885) 0.8px, transparent 0.8px) 0 0 / 20px 20px,
+    var(--background);
 }
 .cmp-canvas-stage {
   display: flex; flex-direction: column; align-items: center;
@@ -897,7 +918,7 @@ textarea.cmp-input { height: auto; padding: 10px 12px; resize: vertical; }
   border-left: 1px solid var(--border); background: var(--card);
   padding: 20px 20px 16px;
   display: flex; flex-direction: column; gap: 16px;
-  overflow-y: auto;
+  min-height: 0; overflow-y: auto;
   animation: cmp-slide-right .15s ease-out;
 }
 .cmp-inspector-head-row { display: flex; align-items: center; justify-content: space-between; }
@@ -1176,6 +1197,8 @@ textarea.cmp-input { height: auto; padding: 10px 12px; resize: vertical; }
 /* ---------- §11.6 Kanban ---------- */
 .cmp-kanban-wrap {
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
   overflow-x: auto;
   padding-bottom: 8px;
   -ms-overflow-style: none;  /* IE and Edge */


### PR DESCRIPTION
Studio editor:
- Fix whole-page scroll: give .cmp-studio-shell a definite viewport height (100dvh - header - inset margins) so only the canvas scrolls; palette and inspector now fit and scroll internally (min-height:0 + overflow-y:auto).
- Dark-mode canvas background (.dark .cmp-canvas-wrap) so the board isn't white in dark theme.
- Hide the floating "Save changes" button while the inspector panel is open (it has its own footer).
- Phone-bot dropdown: resolve saved `script` by bot id OR name, render a fallback item for unknown/failed-to-fetch values, and show the bot name in the hint instead of a raw id.
- Layout containment: min-h-0 on the dashboard children wrapper, min-w-0 on SidebarInset/.cmp-page-pad, and kanban wrap min/max-width so boards scroll internally instead of stretching the page.

Lead-level pause/resume:
- API: POST /campaigns/:id/leads/:leadId/pause|resume, a 'paused' run status
  + paused_at column (migration), and best-effort removal of the run's pending BullMQ job so a paused action can't fire and resume re-enqueues cleanly.
- Editor: LeadDrawer Pause/Resume buttons with optimistic run_status, client helpers, and LeadRunStatus type.

Seed scripts for hotel campaign + WhatsApp blast (env-driven, no secrets).

<!--
Thanks for contributing! Please fill out this template to help us review your PR quickly.
-->

## Summary
<!-- What does this PR do? 1-3 sentences. -->

## Linked issue
Closes #<!-- issue number -->

## Type of change
<!-- Check one -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## How to test
<!-- Steps a reviewer can follow to verify your changes work. -->

1.
2.
3.

## Screenshots (UI changes only)
<!-- Before / After screenshots for any editor UI changes. Delete this section if not applicable. -->

## Checklist
- [ ] This PR targets the `main` branch
- [ ] Code builds: `docker compose build <service>`
- [ ] Types pass: `cd editor && npx tsc --noEmit` (if touching editor)
- [ ] No secrets committed (`.env`, `firebase-sa-key.json`, API keys, etc.)
- [ ] Only shadcn/ui components used (if touching editor UI)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)

## Notes for the reviewer
<!-- Anything non-obvious? Tradeoffs you made? Leftover TODOs? -->
