### PR TITLE
fix(recordings): make cloud archival opt-in, with no default bucket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,11 @@ NEXT_PUBLIC_PBX_URL=http://localhost:8000
 # MSG91_ADMIN_AUTH_KEY=
 # Google Cloud TTS for IVR greeting synthesis (uses GOOGLE_APPLICATION_CREDENTIALS)
 # Google Cloud Storage for recordings (uses GOOGLE_APPLICATION_CREDENTIALS)
+# Leave unset to keep recordings on local disk only. There is deliberately no
+# default bucket — a default would archive your customers' call audio into
+# someone else's storage, on their bill.
 # GCS_BUCKET=
+# GCS_BUCKET_PATH=astra_pbx/recordings
 
 # ── Developer mode only (NOT for self-hosted prod) ──
 # Get these from astradial.com/developers

--- a/api/scripts/move-recordings.sh
+++ b/api/scripts/move-recordings.sh
@@ -13,9 +13,18 @@
 export GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
 
 RECORDING_DIR=/var/spool/asterisk/monitor
-BUCKET=misssellerai.firebasestorage.app
-BUCKET_PATH=astra_pbx/recordings
+# Cloud archival is OPT-IN. There is deliberately no default bucket: a default
+# means every self-hosted install writes its customers' call recordings into
+# whichever bucket happens to be baked into the source — and bills its owner for
+# them. Set GCS_BUCKET (and a credential) to enable archival.
+BUCKET="${GCS_BUCKET:-}"
+BUCKET_PATH="${GCS_BUCKET_PATH:-astra_pbx/recordings}"
 LOG=/var/log/rclone-recordings.log
+
+if [ -z "$BUCKET" ]; then
+  echo "[$(date -Iseconds)] GCS_BUCKET unset — cloud archival disabled, recordings stay in $RECORDING_DIR. Set GCS_BUCKET to enable." >> "$LOG"
+  exit 0
+fi
 
 echo "[$(date -Iseconds)] Starting recording sync" >> $LOG
 
@@ -50,7 +59,7 @@ rclone move $RECORDING_DIR firebase:$BUCKET/$BUCKET_PATH/ \
 echo "[$(date -Iseconds)] Sync complete" >> $LOG
 
 # Also sync ARI bridge recordings (bot calls)
-rclone move /var/spool/asterisk/recording firebase:misssellerai.firebasestorage.app/astra_pbx/recordings/ \
+rclone move /var/spool/asterisk/recording "firebase:$BUCKET/$BUCKET_PATH/" \
   --include "*.wav" \
   --min-age 5m \
   --log-file $LOG \

--- a/api/scripts/stitch-recordings.js
+++ b/api/scripts/stitch-recordings.js
@@ -32,6 +32,10 @@ const STITCH_SRC_DIR = '/var/spool/asterisk/stitch-src';
 // to Firebase by a prior cron run. 25h covers a full missed cycle.
 const LOOKBACK_HOURS = 25;
 
+// Cloud archival is opt-in and has no default bucket.
+const GCS_BUCKET = process.env.GCS_BUCKET || '';
+const GCS_BUCKET_PATH = process.env.GCS_BUCKET_PATH || 'astra_pbx/recordings';
+
 const sequelize = new Sequelize(
   process.env.DB_NAME || 'pbx_api_db',
   process.env.DB_USER || 'root',
@@ -51,10 +55,13 @@ async function resolveLocal(filename) {
   if (fs.existsSync(p)) return p;
   p = path.join(ALT_DIR, filename);
   if (fs.existsSync(p)) return p;
-  // Fetch from Firebase
+  // Fetch from cloud storage, if this install has any configured. No default
+  // bucket: see move-recordings.sh. Unset simply means "legs that are no longer
+  // on disk cannot be recovered", which degrades stitching, never recording.
   const cached = path.join(STITCH_SRC_DIR, filename);
   if (fs.existsSync(cached)) return cached;
-  const remote = `firebase:misssellerai.firebasestorage.app/astra_pbx/recordings/${filename}`;
+  if (!GCS_BUCKET) return null;
+  const remote = `firebase:${GCS_BUCKET}/${GCS_BUCKET_PATH}/${filename}`;
   const ok = await new Promise((resolve) => {
     execFile('rclone', ['copyto', remote, cached, '--timeout', '20s'], { timeout: 30000 }, (err) => resolve(!err));
   });

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -6,6 +6,15 @@
  */
 
 const express = require('express');
+
+// Cloud archival of call recordings is OPT-IN and has no default bucket.
+// A default would mean every self-hosted install writes its customers' call
+// audio into whichever bucket was baked into the source, and bills that
+// bucket's owner. Unset = recordings stay on local disk; playback, stitching
+// and deletion all degrade gracefully rather than reaching for someone
+// else's storage.
+const GCS_BUCKET = process.env.GCS_BUCKET || '';
+const GCS_BUCKET_PATH = process.env.GCS_BUCKET_PATH || 'astra_pbx/recordings';
 const cors = require('cors');
 const morgan = require('morgan');
 const bcrypt = require('bcrypt');
@@ -6838,10 +6847,12 @@ app.get('/api/v1/calls/:callId/recording', async (req, res) => {
       if (fs.existsSync(p)) return p;
       p = path.join(ALT_DIR, filename);
       if (fs.existsSync(p)) return p;
-      // Fetch from Firebase via rclone into the dedicated src cache.
-      const rclonePath = `firebase:misssellerai.firebasestorage.app/astra_pbx/recordings/${filename}`;
+      // Fetch from cloud storage via rclone into the dedicated src cache.
+      // Opt-in: no default bucket (see api/scripts/move-recordings.sh).
       const cached = path.join(STITCH_SRC_DIR, filename);
       if (fs.existsSync(cached)) return cached;
+      if (!GCS_BUCKET) return null;
+      const rclonePath = `firebase:${GCS_BUCKET}/${GCS_BUCKET_PATH}/${filename}`;
       const ok = await new Promise((resolve) => {
         execFile("rclone", ["copyto", rclonePath, cached, "--timeout", "20s"], { timeout: 30000 }, (err) => resolve(!err));
       });
@@ -6954,7 +6965,9 @@ app.get('/api/v1/calls/:callId/recording', async (req, res) => {
     const safeLinkedid = String(anchor.linkedid).replace(/[^a-zA-Z0-9._-]/g, '_');
     const stitchedPath = path.join(STITCH_DIR, `${safeLinkedid}.wav`);
     const stitchedName = `call-${safeLinkedid}.wav`;
-    const stitchedRemote = `firebase:misssellerai.firebasestorage.app/astra_pbx/recordings/stitched/${safeLinkedid}.wav`;
+    const stitchedRemote = GCS_BUCKET
+      ? `firebase:${GCS_BUCKET}/${GCS_BUCKET_PATH}/stitched/${safeLinkedid}.wav`
+      : null;
 
     // Fast path: serve local cached stitch if present, with Range support.
     if (fs.existsSync(stitchedPath)) {
@@ -6969,7 +6982,7 @@ app.get('/api/v1/calls/:callId/recording', async (req, res) => {
     // Note: rclone cat doesn't support Range, so seek doesn't work in this
     // path. Acceptable trade-off — the next request after this populates
     // the local cache, and subsequent requests get full Range support.
-    const remoteMeta = await new Promise((resolve) => {
+    const remoteMeta = !stitchedRemote ? null : await new Promise((resolve) => {
       execFile("rclone", ["size", stitchedRemote, "--json"], { timeout: 10000 }, (err, stdout) => {
         if (err) return resolve(null);
         try { return resolve(JSON.parse(stdout)); } catch { return resolve(null); }
@@ -7377,11 +7390,14 @@ app.delete('/api/v1/calls/:callId/recording', authenticateOrg, requirePermission
       deleted.local = true;
     }
 
-    // Delete from Firebase Storage (GCS via rclone)
+    // Delete from cloud storage, if this install archives anywhere.
+    // Skipped entirely when GCS_BUCKET is unset — there is no default bucket to
+    // delete from, and guessing one would mean issuing deletes against someone
+    // else's storage.
     try {
+      if (!GCS_BUCKET) throw new Error('not found: GCS_BUCKET unset, nothing archived remotely');
       const { execSync } = require('child_process');
-      const bucket = process.env.GCS_BUCKET || 'misssellerai.firebasestorage.app';
-      execSync(`rclone deletefile firebase:${bucket}/astra_pbx/recordings/${filename}`, { timeout: 15000 });
+      execSync(`rclone deletefile firebase:${GCS_BUCKET}/${GCS_BUCKET_PATH}/${filename}`, { timeout: 15000 });
       deleted.gcs = true;
     } catch (e) {
       // File may not exist in GCS (not yet moved or already deleted)

--- a/api/tests/gcs-bucket-optin.test.js
+++ b/api/tests/gcs-bucket-optin.test.js
@@ -1,0 +1,39 @@
+// Cloud archival must be opt-in with NO default bucket.
+//
+// Before this was parameterised, every self-hosted install shipped
+// `misssellerai.firebasestorage.app` hardcoded in five places, so a stranger's
+// `git clone` archived their customers' call recordings into someone else's
+// bucket — and billed that bucket's owner for the storage and egress. That is a
+// data-custody problem before it is a cost one.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const files = [
+  'src/server.js',
+  'scripts/stitch-recordings.js',
+  'scripts/move-recordings.sh',
+];
+
+test('no bucket name is hardcoded anywhere in the archival path', () => {
+  for (const f of files) {
+    const src = fs.readFileSync(path.join(__dirname, '..', f), 'utf8');
+    const hits = src.match(/[a-z0-9-]+\.(firebasestorage\.app|appspot\.com)/gi) || [];
+    assert.deepEqual(hits, [], `${f} hardcodes a bucket: ${hits.join(', ')}`);
+  }
+});
+
+test('GCS_BUCKET has no fallback value', () => {
+  for (const f of ['src/server.js', 'scripts/stitch-recordings.js']) {
+    const src = fs.readFileSync(path.join(__dirname, '..', f), 'utf8');
+    const bad = src.match(/process\.env\.GCS_BUCKET\s*\|\|\s*['"][^'"]+['"]/g) || [];
+    assert.deepEqual(bad, [], `${f} falls back to a literal bucket: ${bad.join(', ')}`);
+  }
+});
+
+test('the sweeper refuses to run without a bucket rather than guessing', () => {
+  const sh = fs.readFileSync(path.join(__dirname, '..', 'scripts/move-recordings.sh'), 'utf8');
+  assert.match(sh, /if \[ -z "\$BUCKET" \]/, 'must guard on an empty bucket');
+  assert.match(sh, /exit 0/, 'must exit cleanly, leaving recordings on local disk');
+});


### PR DESCRIPTION
## The problem

Five sites hardcoded `misssellerai.firebasestorage.app` — the bucket belonging to the project this code was extracted from:

```
api/scripts/move-recordings.sh:16,53
api/scripts/stitch-recordings.js:57
api/src/server.js:6848,6963
```

Any self-hosted install therefore archived **its customers' call recordings into someone else's bucket**, and billed that bucket's owner for the storage and egress.

That's a data-custody problem before it's a cost one. Hospital and BPO call audio was being written to storage the operator neither controls, can audit, nor can erase from — which also means a self-hoster cannot honour a deletion request against their own recordings.

## The part that makes it worse

`.env.example` already advertised `GCS_BUCKET` as an optional setting. Only **one** of the five sites read it, and even that one fell back to the literal bucket when unset:

```js
const bucket = process.env.GCS_BUCKET || 'misssellerai.firebasestorage.app';
```

So the documented way to opt out did nothing at all.

## After

Archival is opt-in, with no default:

| `GCS_BUCKET` | Behaviour |
|---|---|
| unset | Recordings stay in `/var/spool/asterisk/monitor`. Sweeper logs why and exits 0; stitching skips remote leg recovery; delete skips the remote object rather than guessing a bucket to issue deletes against |
| set | Unchanged, against the operator's own bucket |

`GCS_BUCKET_PATH` (default `astra_pbx/recordings`) replaces the second hardcoded path segment, which was also duplicated literally in three places.

Degradation is graceful in the direction that matters: recording capture is untouched, and everything that fails without a bucket fails toward *keeping local audio*, never toward losing it.

## Test

`api/tests/gcs-bucket-optin.test.js` — 3/3 pass. Asserts no bucket literal survives anywhere in the archival path, that `GCS_BUCKET` has no fallback, and that the sweeper refuses to run rather than guessing.

## Context

Found while auditing the upstream project's Cloud Storage spend. The same bucket was also, separately, world-readable until today — so this hardcoded name was a published pointer to an open bucket. Both are now closed.

Verified that the one known self-hosted install (Skylink) has no rclone, no credential and no recording cron, so it was never archiving remotely and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjmJNshqHAZzsoncWmXbfS